### PR TITLE
fix(indexer): prevent duplicate tx ingestion when processing latest ledger

### DIFF
--- a/indexer/internal/pipeline/live.go
+++ b/indexer/internal/pipeline/live.go
@@ -139,9 +139,10 @@ func (p *LivePipeline) processLedgerBatch(ctx context.Context, startLedger uint3
 	}
 
 	// Fetch transactions for this ledger range
+	const txPageLimit = 200
 	txResult, err := p.rpc.GetTransactions(ctx, source.GetTransactionsParams{
 		StartLedger: startLedger,
-		Pagination:  &source.Pagination{Limit: 200},
+		Pagination:  &source.Pagination{Limit: txPageLimit},
 	})
 	if err != nil {
 		return 0, fmt.Errorf("getTransactions: %w", err)
@@ -150,6 +151,13 @@ func (p *LivePipeline) processLedgerBatch(ctx context.Context, startLedger uint3
 	// Paginate through all transactions in this range
 	allTxEntries := txResult.Transactions
 	for txResult.Cursor != "" {
+		// If the previous page was not full, we've exhausted all available data.
+		// This also handles the edge case where the target ledger IS the latest
+		// ledger: the RPC returns a partial page with only that ledger's txs and
+		// a cursor that loops back, causing infinite duplicate fetches.
+		if len(txResult.Transactions) < txPageLimit {
+			break
+		}
 		lastTxLedger := uint32(0)
 		if len(txResult.Transactions) > 0 {
 			lastTxLedger = txResult.Transactions[len(txResult.Transactions)-1].Ledger
@@ -161,7 +169,7 @@ func (p *LivePipeline) processLedgerBatch(ctx context.Context, startLedger uint3
 		}
 
 		txResult, err = p.rpc.GetTransactions(ctx, source.GetTransactionsParams{
-			Pagination: &source.Pagination{Cursor: txResult.Cursor, Limit: 200},
+			Pagination: &source.Pagination{Cursor: txResult.Cursor, Limit: txPageLimit},
 		})
 		if err != nil {
 			return 0, fmt.Errorf("getTransactions (pagination): %w", err)


### PR DESCRIPTION
## Summary                                                                                                                                                            

  - Fix pagination bug in `processLedgerBatch` that caused transactions to be counted 2-4x when ingesting the latest ledger in live mode                                
  - Add partial-page check to break the pagination loop when all available data has been exhausted                                                                      

  ## Problem

  When the live pipeline processes the most recent ledger, the Stellar RPC `getTransactions` returns only that ledger's transactions (fewer than the 200-entry page limit). The pagination cursor is still non-empty, but the break condition `lastTxLedger > endLedger` is never satisfied because `lastTxLedger == endLedger`. The RPC
  then enters a cursor ping-pong loop, re-returning the same transactions on alternating pages until a new ledger closes and breaks the cycle.

  This caused variable overcounting (2-4x) depending on how many loop iterations occurred before the next ledger closed.

  ## Fix

  Added a check at the top of the pagination loop: if the previous page returned fewer results than the page limit, all available data has been exhausted and pagination stops. This correctly handles all cases:

  - **Latest ledger** (the bug): partial first page → stop immediately
  - **Multi-ledger batches**: full pages → continue until past range or partial
  - **Large ledgers (200+ txs)**: full page from single ledger → continue fetching
