### PR TITLE
feat(indexer): CAP-67 token event processing

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,4 +7,5 @@ coverage
 pnpm-lock.yaml
 package-lock.json
 .claude/
+.agents/
 docs/

--- a/docs/src/content/docs/architecture/indexer-token-events.md
+++ b/docs/src/content/docs/architecture/indexer-token-events.md
@@ -1,0 +1,140 @@
+---
+title: "CAP-67 Token Event Processing"
+description: How the indexer extracts unified token transfer events from every ledger using the Stellar Token Transfer Processor.
+---
+
+## What This Enables
+
+Before CAP-67, tracking token movements on Stellar required separate pipelines: ledger state diffs for classic assets and contract event logs for Soroban tokens. They used different formats, different APIs, and had no common schema.
+
+CAP-67 introduces a **single unified event stream** that covers every token value movement on the network regardless of whether the asset is a classic Stellar asset (XLM, USDC) or a pure Soroban token. This task implements the indexer side of that stream.
+
+With this in place, the explorer can:
+
+- Show a complete transfer history for any account without merging two different data sources
+- Display mint, burn, and clawback events alongside regular transfers in a single unified feed
+- Track fee payments as first-class events, not as metadata buried inside transaction envelopes
+- Compute circulating supply for any token as `SUM(mint) - SUM(burn)`, directly from the database
+
+## How It Works
+
+The indexer uses the **Token Transfer Processor** (TTP) from `github.com/stellar/go-stellar-sdk/processors/token_transfer`. For each ledger, `TokenEventsFromLedgerMeta` decodes the `LedgerCloseMeta` XDR that the RPC returns in the `metadataXdr` field of `getLedgers`, and feeds it to `EventsProcessor.EventsFromLedger()`.
+
+The TTP normalises everything into `TokenTransferEvent` protobuf messages. Each event carries:
+
+| Field | Description |
+|---|---|
+| `event_type` | `0` transfer · `1` mint · `2` burn · `3` clawback · `4` fee |
+| `from_address` / `to_address` | Sender and receiver (with muxed variants) |
+| `asset_type` | `0` native · `1` classic credit · `2` pure Soroban token |
+| `asset_code` / `asset_issuer` | Present for credit assets |
+| `asset_contract_id` | Present for Soroban tokens and SAC-wrapped classic assets |
+| `amount` | i128 raw value as a decimal string |
+| `ledger_sequence` / `transaction_hash` | Traceability back to the source |
+
+These are batch-inserted into the `token_events` TimescaleDB hypertable after every ledger.
+
+**Code path:**
+
+```
+source/rpc.go (getLedgers metadataXdr)
+  → transform/token_events.go TokenEventsFromLedgerMeta()
+    → TTP EventsProcessor.EventsFromLedger()
+      → store/postgres.go InsertTokenEventBatch()
+        → token_events (TimescaleDB hypertable)
+```
+
+## Verifying It Works
+
+### Prerequisites
+
+Docker services running and migrations applied (see the [indexer README](https://github.com/salazarsebas/stellar-explorer/blob/main/indexer/README.md)).
+
+### 1. Run the indexer against testnet
+
+```bash
+RPC_ENDPOINT=https://soroban-testnet.stellar.org NETWORK=testnet ./bin/indexer live
+```
+
+Wait for a few ledgers to be ingested (watch for `ingested ledger XXXXXXX` in the logs).
+
+### 2. Check that token events landed
+
+```bash
+docker compose exec postgres psql -U explorer -d stellar_explorer -c "
+SELECT event_type_name, from_address, to_address, asset_code, amount, transaction_hash
+FROM token_events
+ORDER BY created_at DESC
+LIMIT 10;
+"
+```
+
+You should see rows with `transfer`, `fee`, `mint`, or `burn` in the `event_type_name` column.
+
+### 3. Inspect a specific event type
+
+```bash
+# Native XLM fee events (present in almost every ledger)
+docker compose exec postgres psql -U explorer -d stellar_explorer -c "
+SELECT event_type_name, from_address, asset_code, amount, ledger_sequence
+FROM token_events
+WHERE event_type_name = 'fee'
+ORDER BY created_at DESC
+LIMIT 5;
+"
+
+# Transfers (classic + Soroban)
+docker compose exec postgres psql -U explorer -d stellar_explorer -c "
+SELECT event_type_name, from_address, to_address, asset_type, asset_code, asset_contract_id, amount
+FROM token_events
+WHERE event_type_name = 'transfer'
+ORDER BY created_at DESC
+LIMIT 10;
+"
+
+# Transfers involving a contract address on either side (Soroban-native activity)
+docker compose exec postgres psql -U explorer -d stellar_explorer -c "
+SELECT
+  event_type_name,
+  from_address,
+  CASE WHEN from_address LIKE 'C%' THEN true ELSE false END AS from_is_contract,
+  to_address,
+  CASE WHEN to_address LIKE 'C%' THEN true ELSE false END AS to_is_contract,
+  asset_type,
+  asset_code,
+  asset_contract_id,
+  amount,
+  transaction_hash
+FROM token_events
+WHERE event_type_name = 'transfer'
+  AND (from_address LIKE 'C%' OR to_address LIKE 'C%')
+ORDER BY created_at DESC
+LIMIT 10;
+"
+```
+
+### 4. Count by type to see the breakdown
+
+```bash
+docker compose exec postgres psql -U explorer -d stellar_explorer -c "
+SELECT event_type_name, COUNT(*) as total
+FROM token_events
+GROUP BY event_type_name
+ORDER BY total DESC;
+"
+```
+
+### 5. Run the unit tests
+
+```bash
+go test ./internal/transform/ -run TestTokenEvent -v
+```
+
+These tests exercise the proto-to-store mapping for transfer, mint, Soroban token, and fee events without hitting the network.
+
+## Notes
+
+- Fee events have no `operation_index` (they are not tied to a specific operation).
+- Pure Soroban tokens (`asset_type = 2`) have no `asset_code` or `asset_issuer` — only `asset_contract_id`.
+- `amount` is stored as a raw i128 decimal string. Formatting it for display requires the token's `decimals` value from the `contracts` table (populated by Task 3.3).
+- If `metadataXdr` is missing from a ledger (possible on older protocol versions), the processor returns an empty list and the ledger is still ingested without error.

--- a/indexer/go.mod
+++ b/indexer/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/lib/pq v1.11.2
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/stellar/go-stellar-sdk v0.1.0
+	google.golang.org/protobuf v1.34.2
 )
 
 require (
@@ -50,6 +51,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
@@ -93,7 +95,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240701130421-f6361c86f094 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240701130421-f6361c86f094 // indirect
 	google.golang.org/grpc v1.64.1 // indirect
-	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/djherbis/atime.v1 v1.0.0 // indirect
 	gopkg.in/djherbis/stream.v1 v1.3.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/indexer/internal/pipeline/live.go
+++ b/indexer/internal/pipeline/live.go
@@ -244,6 +244,14 @@ func ProcessOneLedger(ctx context.Context, db *store.PostgresStore, pub Publishe
 	}
 	ledger.OperationCount = opCount
 
+	// Extract CAP-67 token events from LedgerCloseMeta
+	tokenEvents, err := transform.TokenEventsFromLedgerMeta(ledgerEntry.MetadataXDR, networkPassphrase)
+	if err != nil {
+		log.Printf("ledger %d: token event extraction warning: %v", ledgerEntry.Sequence, err)
+		// Non-fatal: continue without token events
+		tokenEvents = nil
+	}
+
 	// Write to database
 	if err := db.InsertLedger(ctx, ledger); err != nil {
 		return fmt.Errorf("insert ledger: %w", err)
@@ -253,6 +261,9 @@ func ProcessOneLedger(ctx context.Context, db *store.PostgresStore, pub Publishe
 	}
 	if err := db.InsertOperationBatch(ctx, storeOps); err != nil {
 		return fmt.Errorf("insert operations: %w", err)
+	}
+	if err := db.InsertTokenEventBatch(ctx, tokenEvents); err != nil {
+		return fmt.Errorf("insert token events: %w", err)
 	}
 
 	// Update cursor

--- a/indexer/internal/store/models.go
+++ b/indexer/internal/store/models.go
@@ -74,3 +74,24 @@ type Effect struct {
 	Details         string    `db:"details"` // JSON
 	CreatedAt       time.Time `db:"created_at"`
 }
+
+// TokenEvent represents a row in the token_events hypertable (CAP-67 unified events).
+type TokenEvent struct {
+	EventType       int16     `db:"event_type"`      // 0=transfer, 1=mint, 2=burn, 3=clawback, 4=fee
+	EventTypeName   string    `db:"event_type_name"` // "transfer", "mint", etc.
+	FromAddress     *string   `db:"from_address"`
+	FromMuxed       *string   `db:"from_muxed"`
+	ToAddress       *string   `db:"to_address"`
+	ToMuxed         *string   `db:"to_muxed"`
+	ToMuxedID       *int64    `db:"to_muxed_id"`
+	AssetType       int16     `db:"asset_type"`       // 0=native, 1=credit, 2=soroban_token
+	AssetCode       *string   `db:"asset_code"`
+	AssetIssuer     *string   `db:"asset_issuer"`
+	AssetContractID *string   `db:"asset_contract_id"`
+	Amount          string    `db:"amount"`           // i128 as decimal string
+	AmountFormatted *string   `db:"amount_formatted"` // formatted with decimals (optional)
+	TransactionHash string    `db:"transaction_hash"`
+	LedgerSequence  uint32    `db:"ledger_sequence"`
+	OperationIndex  *int32    `db:"operation_index"`
+	CreatedAt       time.Time `db:"created_at"`
+}

--- a/indexer/internal/store/postgres.go
+++ b/indexer/internal/store/postgres.go
@@ -112,6 +112,44 @@ func (s *PostgresStore) InsertOperationBatch(ctx context.Context, ops []Operatio
 	return dbTx.Commit()
 }
 
+func (s *PostgresStore) InsertTokenEventBatch(ctx context.Context, events []TokenEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+	dbTx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer dbTx.Rollback()
+
+	stmt, err := dbTx.PrepareContext(ctx, `
+		INSERT INTO token_events (
+			event_type, event_type_name,
+			from_address, from_muxed, to_address, to_muxed, to_muxed_id,
+			asset_type, asset_code, asset_issuer, asset_contract_id,
+			amount, amount_formatted,
+			transaction_hash, ledger_sequence, operation_index, created_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for _, e := range events {
+		_, err := stmt.ExecContext(ctx,
+			e.EventType, e.EventTypeName,
+			e.FromAddress, e.FromMuxed, e.ToAddress, e.ToMuxed, e.ToMuxedID,
+			e.AssetType, e.AssetCode, e.AssetIssuer, e.AssetContractID,
+			e.Amount, e.AmountFormatted,
+			e.TransactionHash, e.LedgerSequence, e.OperationIndex, e.CreatedAt)
+		if err != nil {
+			return err
+		}
+	}
+
+	return dbTx.Commit()
+}
+
 // GetLastIngestedLedger returns the last processed ledger sequence.
 func (s *PostgresStore) GetLastIngestedLedger(ctx context.Context) (uint32, error) {
 	var seq uint32

--- a/indexer/internal/transform/token_events.go
+++ b/indexer/internal/transform/token_events.go
@@ -1,0 +1,176 @@
+package transform
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	assetProto "github.com/stellar/go-stellar-sdk/asset"
+	"github.com/stellar/go-stellar-sdk/processors/token_transfer"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/miguelnietoa/stellar-explorer/indexer/internal/store"
+)
+
+const (
+	tokenEventTypeTransfer int16 = 0
+	tokenEventTypeMint     int16 = 1
+	tokenEventTypeBurn     int16 = 2
+	tokenEventTypeClawback int16 = 3
+	tokenEventTypeFee      int16 = 4
+
+	assetTypeNative       int16 = 0
+	assetTypeCredit       int16 = 1
+	assetTypeSorobanToken int16 = 2
+)
+
+// TokenEventsFromLedgerMeta extracts CAP-67 unified token transfer events from a
+// base64-encoded LedgerCloseMeta XDR string (the metadataXdr field from getLedgers RPC).
+func TokenEventsFromLedgerMeta(metaXDR string, networkPassphrase string) ([]store.TokenEvent, error) {
+	if metaXDR == "" {
+		return nil, nil
+	}
+
+	var lcm xdr.LedgerCloseMeta
+	if err := xdr.SafeUnmarshalBase64(metaXDR, &lcm); err != nil {
+		return nil, fmt.Errorf("unmarshal LedgerCloseMeta: %w", err)
+	}
+
+	ttp := token_transfer.NewEventsProcessor(networkPassphrase)
+	events, err := ttp.EventsFromLedger(lcm)
+	if err != nil {
+		return nil, fmt.Errorf("extract token events from ledger: %w", err)
+	}
+
+	result := make([]store.TokenEvent, 0, len(events))
+	for _, event := range events {
+		te, err := tokenEventFromProto(event)
+		if err != nil {
+			log.Printf("token_events: skip event: %v", err)
+			continue
+		}
+		result = append(result, *te)
+	}
+	return result, nil
+}
+
+func tokenEventFromProto(event *token_transfer.TokenTransferEvent) (*store.TokenEvent, error) {
+	meta := event.GetMeta()
+	if meta == nil {
+		return nil, fmt.Errorf("event has no meta")
+	}
+
+	eventTypeName := event.GetEventType()
+	var eventType int16
+	var fromAddr, toAddr *string
+
+	switch e := event.GetEvent().(type) {
+	case *token_transfer.TokenTransferEvent_Transfer:
+		eventType = tokenEventTypeTransfer
+		from := e.Transfer.GetFrom()
+		to := e.Transfer.GetTo()
+		if from != "" {
+			fromAddr = &from
+		}
+		if to != "" {
+			toAddr = &to
+		}
+	case *token_transfer.TokenTransferEvent_Mint:
+		eventType = tokenEventTypeMint
+		to := e.Mint.GetTo()
+		if to != "" {
+			toAddr = &to
+		}
+	case *token_transfer.TokenTransferEvent_Burn:
+		eventType = tokenEventTypeBurn
+		from := e.Burn.GetFrom()
+		if from != "" {
+			fromAddr = &from
+		}
+	case *token_transfer.TokenTransferEvent_Clawback:
+		eventType = tokenEventTypeClawback
+		from := e.Clawback.GetFrom()
+		if from != "" {
+			fromAddr = &from
+		}
+	case *token_transfer.TokenTransferEvent_Fee:
+		eventType = tokenEventTypeFee
+		from := e.Fee.GetFrom()
+		if from != "" {
+			fromAddr = &from
+		}
+	default:
+		return nil, fmt.Errorf("unknown event type: %T", event.GetEvent())
+	}
+
+	// Muxed destination info
+	var toMuxedID *int64
+	if muxedInfo := meta.GetToMuxedInfo(); muxedInfo != nil {
+		if idInfo, ok := muxedInfo.Content.(*token_transfer.MuxedInfo_Id); ok {
+			id := int64(idInfo.Id)
+			toMuxedID = &id
+		}
+	}
+
+	// Asset classification
+	assetType, assetCode, assetIssuer, assetContractID := mapProtoAsset(event.GetAsset(), meta.GetContractAddress())
+
+	// Operation index (nil for fee events, which have no operation)
+	var opIndex *int32
+	if meta.OperationIndex != nil {
+		idx := int32(meta.GetOperationIndex())
+		opIndex = &idx
+	}
+
+	// Ledger close time
+	var createdAt time.Time
+	if ts := meta.GetClosedAt(); ts != nil {
+		createdAt = ts.AsTime()
+	}
+
+	return &store.TokenEvent{
+		EventType:       eventType,
+		EventTypeName:   eventTypeName,
+		FromAddress:     fromAddr,
+		ToAddress:       toAddr,
+		ToMuxedID:       toMuxedID,
+		AssetType:       assetType,
+		AssetCode:       assetCode,
+		AssetIssuer:     assetIssuer,
+		AssetContractID: assetContractID,
+		Amount:          event.GetAmount(),
+		TransactionHash: meta.GetTxHash(),
+		LedgerSequence:  meta.GetLedgerSequence(),
+		OperationIndex:  opIndex,
+		CreatedAt:       createdAt,
+	}, nil
+}
+
+// mapProtoAsset determines the DB asset type, code, issuer, and contract ID from the
+// proto Asset (which is nil for pure Soroban tokens) and the ContractAddress in EventMeta.
+func mapProtoAsset(a *assetProto.Asset, contractAddress string) (assetType int16, code *string, issuer *string, contractID *string) {
+	var contractIDPtr *string
+	if contractAddress != "" {
+		contractIDPtr = &contractAddress
+	}
+
+	if a == nil {
+		// Pure Soroban token: no underlying classic asset
+		return assetTypeSorobanToken, nil, nil, contractIDPtr
+	}
+
+	switch a.GetAssetType().(type) {
+	case *assetProto.Asset_Native:
+		xlm := "XLM"
+		return assetTypeNative, &xlm, nil, contractIDPtr
+	case *assetProto.Asset_IssuedAsset:
+		ia := a.GetIssuedAsset()
+		c := ia.GetAssetCode()
+		i := ia.GetIssuer()
+		return assetTypeCredit, &c, &i, contractIDPtr
+	default:
+		// Fallback: treat as native if type is unrecognized
+		xlm := "XLM"
+		return assetTypeNative, &xlm, nil, contractIDPtr
+	}
+}

--- a/indexer/internal/transform/token_events_test.go
+++ b/indexer/internal/transform/token_events_test.go
@@ -1,0 +1,168 @@
+package transform
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	assetProto "github.com/stellar/go-stellar-sdk/asset"
+	"github.com/stellar/go-stellar-sdk/network"
+	"github.com/stellar/go-stellar-sdk/processors/token_transfer"
+	"github.com/stellar/go-stellar-sdk/xdr"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// makeTestMeta creates a minimal EventMeta for tests.
+func makeTestMeta(ledger uint32, txHash string, opIdx *uint32) *token_transfer.EventMeta {
+	return &token_transfer.EventMeta{
+		LedgerSequence: ledger,
+		ClosedAt:       timestamppb.New(time.Unix(1700000000, 0)),
+		TxHash:         txHash,
+		OperationIndex: opIdx,
+	}
+}
+
+func opIndexPtr(i uint32) *uint32 { return &i }
+
+func nativeXDRAsset() xdr.Asset {
+	return xdr.Asset{Type: xdr.AssetTypeAssetTypeNative}
+}
+
+func creditXDRAsset(code, issuer string) xdr.Asset {
+	if len(code) <= 4 {
+		var c [4]byte
+		copy(c[:], strings.TrimRight(code, "\x00"))
+		return xdr.Asset{
+			Type: xdr.AssetTypeAssetTypeCreditAlphanum4,
+			AlphaNum4: &xdr.AlphaNum4{
+				AssetCode: xdr.AssetCode4(c),
+				Issuer:    xdr.MustAddress(issuer),
+			},
+		}
+	}
+	var c [12]byte
+	copy(c[:], strings.TrimRight(code, "\x00"))
+	return xdr.Asset{
+		Type: xdr.AssetTypeAssetTypeCreditAlphanum12,
+		AlphaNum12: &xdr.AlphaNum12{
+			AssetCode: xdr.AssetCode12(c),
+			Issuer:    xdr.MustAddress(issuer),
+		},
+	}
+}
+
+func TestTokenEventFromProto_Transfer(t *testing.T) {
+	meta := makeTestMeta(100, "abc123", opIndexPtr(1))
+	protoAsset := assetProto.NewProtoAsset(nativeXDRAsset())
+	event := token_transfer.NewTransferEvent(meta, "GABC", "GDEF", "5000000", protoAsset)
+
+	te, err := tokenEventFromProto(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if te.EventType != tokenEventTypeTransfer {
+		t.Errorf("expected transfer type (0), got %d", te.EventType)
+	}
+	if te.EventTypeName != "transfer" {
+		t.Errorf("expected 'transfer', got %q", te.EventTypeName)
+	}
+	if te.FromAddress == nil || *te.FromAddress != "GABC" {
+		t.Errorf("expected from=GABC, got %v", te.FromAddress)
+	}
+	if te.ToAddress == nil || *te.ToAddress != "GDEF" {
+		t.Errorf("expected to=GDEF, got %v", te.ToAddress)
+	}
+	if te.Amount != "5000000" {
+		t.Errorf("expected amount=5000000, got %q", te.Amount)
+	}
+	if te.AssetType != assetTypeNative {
+		t.Errorf("expected native asset type, got %d", te.AssetType)
+	}
+	if te.LedgerSequence != 100 {
+		t.Errorf("expected ledger 100, got %d", te.LedgerSequence)
+	}
+	if te.OperationIndex == nil || *te.OperationIndex != 1 {
+		t.Errorf("expected operation_index=1, got %v", te.OperationIndex)
+	}
+}
+
+func TestTokenEventFromProto_Mint(t *testing.T) {
+	const usdcIssuer = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+	meta := makeTestMeta(200, "def456", opIndexPtr(2))
+	usdcXDR := creditXDRAsset("USDC", usdcIssuer)
+	usdcProto := assetProto.NewProtoAsset(usdcXDR)
+	event := token_transfer.NewMintEvent(meta, "GXYZ", "100000000000", usdcProto)
+
+	te, err := tokenEventFromProto(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if te.EventType != tokenEventTypeMint {
+		t.Errorf("expected mint type (1), got %d", te.EventType)
+	}
+	if te.FromAddress != nil {
+		t.Errorf("expected nil from for mint, got %v", te.FromAddress)
+	}
+	if te.AssetType != assetTypeCredit {
+		t.Errorf("expected credit asset type, got %d", te.AssetType)
+	}
+	if te.AssetCode == nil || *te.AssetCode != "USDC" {
+		t.Errorf("expected USDC, got %v", te.AssetCode)
+	}
+	if te.AssetIssuer == nil || *te.AssetIssuer != usdcIssuer {
+		t.Errorf("expected issuer %q, got %v", usdcIssuer, te.AssetIssuer)
+	}
+}
+
+func TestTokenEventFromProto_SorobanToken(t *testing.T) {
+	contractAddr := "CABC123XYZ"
+	meta := makeTestMeta(300, "ghi789", opIndexPtr(1))
+	meta.ContractAddress = contractAddr
+	// Pure Soroban token: asset is nil
+	event := token_transfer.NewTransferEvent(meta, "GABC", "GDEF", "999", nil)
+
+	te, err := tokenEventFromProto(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if te.AssetType != assetTypeSorobanToken {
+		t.Errorf("expected soroban_token asset type (2), got %d", te.AssetType)
+	}
+	if te.AssetContractID == nil || *te.AssetContractID != contractAddr {
+		t.Errorf("expected contract_id=%q, got %v", contractAddr, te.AssetContractID)
+	}
+	if te.AssetCode != nil {
+		t.Errorf("expected nil asset_code for soroban token, got %v", te.AssetCode)
+	}
+}
+
+func TestTokenEventFromProto_FeeHasNoOperationIndex(t *testing.T) {
+	meta := makeTestMeta(400, "jkl012", nil) // fee events have no operation index
+	xlmProto := assetProto.NewProtoAsset(nativeXDRAsset())
+	event := token_transfer.NewFeeEvent(meta, "GABC", "100", xlmProto)
+
+	te, err := tokenEventFromProto(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if te.EventType != tokenEventTypeFee {
+		t.Errorf("expected fee type (4), got %d", te.EventType)
+	}
+	if te.OperationIndex != nil {
+		t.Errorf("expected nil operation_index for fee event, got %v", te.OperationIndex)
+	}
+}
+
+func TestTokenEventsFromLedgerMeta_EmptyMeta(t *testing.T) {
+	events, err := TokenEventsFromLedgerMeta("", network.PublicNetworkPassphrase)
+	if err != nil {
+		t.Fatalf("unexpected error for empty meta: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected 0 events for empty meta, got %d", len(events))
+	}
+}


### PR DESCRIPTION
Closes https://github.com/salazarsebas/stellar-explorer/issues/14

Adds unified token event extraction from LedgerCloseMeta using the Stellar Token Transfer Processor (TTP).
Captures transfer, mint, burn, clawback, and fee events for both classic assets and Soroban tokens in a single pipeline pass, stored in the `token_events` hypertable.
    
- store: TokenEvent model + InsertTokenEventBatch
- transform: TokenEventsFromLedgerMeta via TTP EventsProcessor
- pipeline: wire token event extraction into ProcessOneLedger