### PR TITLE
Improve explorer indexability and canonical SEO signals

### DIFF
--- a/src/app/[locale]/[network]/(explorer)/account/[id]/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/account/[id]/page.tsx
@@ -1,15 +1,20 @@
 import { Metadata } from "next";
 import { AccountContent } from "./account-content";
+import { buildExplorerMetadata } from "@/lib/seo";
+import type { NetworkKey } from "@/types";
 
 type Props = {
-  params: Promise<{ id: string }>;
+  params: Promise<{ locale: string; network: string; id: string }>;
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { id } = await params;
+  const { locale, network, id } = await params;
   const shortId = `${id.slice(0, 6)}...${id.slice(-6)}`;
 
-  return {
+  return buildExplorerMetadata({
+    locale,
+    network: network as NetworkKey,
+    pathname: `/account/${id}`,
     title: `Account ${shortId}`,
     description: `View Stellar account ${shortId}. Explore balances, transactions, operations, and signers.`,
     openGraph: {
@@ -22,7 +27,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title: `Stellar Account ${shortId}`,
       description: `View account details on Stellar Explorer`,
     },
-  };
+  });
 }
 
 export default async function AccountPage({ params }: Props) {

--- a/src/app/[locale]/[network]/(explorer)/accounts/layout.tsx
+++ b/src/app/[locale]/[network]/(explorer)/accounts/layout.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from "next";
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { buildExplorerMetadata } from "@/lib/seo";
 import type { NetworkKey } from "@/types";
@@ -9,22 +9,22 @@ export async function generateMetadata({
   params: Promise<{ locale: string; network: string }>;
 }): Promise<Metadata> {
   const { locale, network } = await params;
-  const t = await getTranslations({ locale, namespace: "assets" });
+  const t = await getTranslations({ locale, namespace: "accounts" });
 
   return buildExplorerMetadata({
     locale,
     network: network as NetworkKey,
-    pathname: "/assets",
+    pathname: "/accounts",
     title: t("title"),
-    description: t("metaDescription"),
+    description: t("subtitle"),
     openGraph: {
       title: t("title"),
-      description: t("metaDescription"),
+      description: t("subtitle"),
       type: "website",
     },
   });
 }
 
-export default function AssetsLayout({ children }: { children: React.ReactNode }) {
+export default function AccountsLayout({ children }: { children: React.ReactNode }) {
   return children;
 }

--- a/src/app/[locale]/[network]/(explorer)/analytics/layout.tsx
+++ b/src/app/[locale]/[network]/(explorer)/analytics/layout.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from "next";
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { buildExplorerMetadata } from "@/lib/seo";
 import type { NetworkKey } from "@/types";
@@ -9,22 +9,18 @@ export async function generateMetadata({
   params: Promise<{ locale: string; network: string }>;
 }): Promise<Metadata> {
   const { locale, network } = await params;
-  const t = await getTranslations({ locale, namespace: "assets" });
+  const t = await getTranslations({ locale, namespace: "analytics" });
 
   return buildExplorerMetadata({
     locale,
     network: network as NetworkKey,
-    pathname: "/assets",
+    pathname: "/analytics",
     title: t("title"),
-    description: t("metaDescription"),
-    openGraph: {
-      title: t("title"),
-      description: t("metaDescription"),
-      type: "website",
-    },
+    description: t("subtitle"),
+    index: false,
   });
 }
 
-export default function AssetsLayout({ children }: { children: React.ReactNode }) {
+export default function AnalyticsLayout({ children }: { children: React.ReactNode }) {
   return children;
 }

--- a/src/app/[locale]/[network]/(explorer)/asset/[slug]/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/asset/[slug]/page.tsx
@@ -1,13 +1,15 @@
 import { Metadata } from "next";
 import { AssetContent } from "./asset-content";
 import { parseAssetSlug } from "@/lib/utils";
+import { buildExplorerMetadata } from "@/lib/seo";
+import type { NetworkKey } from "@/types";
 
 type Props = {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ locale: string; network: string; slug: string }>;
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { slug } = await params;
+  const { locale, network, slug } = await params;
   const parsed = parseAssetSlug(slug);
 
   if (!parsed) {
@@ -20,7 +22,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const isNative = issuer === "native";
   const shortIssuer = isNative ? "Native" : `${issuer.slice(0, 4)}...${issuer.slice(-4)}`;
 
-  return {
+  return buildExplorerMetadata({
+    locale,
+    network: network as NetworkKey,
+    pathname: `/asset/${slug}`,
     title: isNative ? "XLM - Stellar Lumens" : `${code} Asset`,
     description: isNative
       ? "XLM (Stellar Lumens) is the native asset of the Stellar network."
@@ -39,7 +44,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         ? "Native asset of the Stellar network"
         : `View ${code} asset details on Stellar Explorer`,
     },
-  };
+  });
 }
 
 export default async function AssetPage({ params }: Props) {

--- a/src/app/[locale]/[network]/(explorer)/contract/[id]/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/contract/[id]/page.tsx
@@ -1,15 +1,20 @@
 import { Metadata } from "next";
 import { ContractContent } from "./contract-content";
+import { buildExplorerMetadata } from "@/lib/seo";
+import type { NetworkKey } from "@/types";
 
 type Props = {
-  params: Promise<{ id: string }>;
+  params: Promise<{ locale: string; network: string; id: string }>;
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { id } = await params;
+  const { locale, network, id } = await params;
   const shortId = `${id.slice(0, 6)}...${id.slice(-6)}`;
 
-  return {
+  return buildExplorerMetadata({
+    locale,
+    network: network as NetworkKey,
+    pathname: `/contract/${id}`,
     title: `Contract ${shortId}`,
     description: `View Soroban smart contract ${shortId}. Explore events, storage, and contract code on Stellar.`,
     openGraph: {
@@ -22,7 +27,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title: `Soroban Contract ${shortId}`,
       description: `View smart contract details on Stellar Explorer`,
     },
-  };
+  });
 }
 
 export default async function ContractPage({ params }: Props) {

--- a/src/app/[locale]/[network]/(explorer)/contracts/layout.tsx
+++ b/src/app/[locale]/[network]/(explorer)/contracts/layout.tsx
@@ -1,23 +1,28 @@
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
+import { buildExplorerMetadata } from "@/lib/seo";
+import type { NetworkKey } from "@/types";
 
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ locale: string }>;
+  params: Promise<{ locale: string; network: string }>;
 }): Promise<Metadata> {
-  const { locale } = await params;
+  const { locale, network } = await params;
   const t = await getTranslations({ locale, namespace: "contracts" });
 
-  return {
-    title: t("metaTitle"),
+  return buildExplorerMetadata({
+    locale,
+    network: network as NetworkKey,
+    pathname: "/contracts",
+    title: t("title"),
     description: t("metaDescription"),
     openGraph: {
-      title: t("metaTitle"),
+      title: t("title"),
       description: t("metaDescription"),
       type: "website",
     },
-  };
+  });
 }
 
 export default function ContractsLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/[locale]/[network]/(explorer)/home-page-client.tsx
+++ b/src/app/[locale]/[network]/(explorer)/home-page-client.tsx
@@ -1,0 +1,381 @@
+"use client";
+
+import { Suspense } from "react";
+import { Layers, Activity, Wallet, TrendingUp, Sparkles, BarChart3 } from "lucide-react";
+import { DashboardCharts } from "@/components/charts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { TransactionCard, TransactionCardSkeleton } from "@/components/cards/transaction-card";
+import { LedgerCard, LedgerCardSkeleton } from "@/components/cards/ledger-card";
+import { NetworkStatsCard } from "@/components/stats";
+import { LiveIndicator } from "@/components/common/live-indicator";
+import {
+  useLatestLedger,
+  useRecentTransactions,
+  useFeeStats,
+  useLedgerStream,
+  useTransactionStream,
+} from "@/lib/hooks";
+import { formatLedgerSequence, stroopsToXLM } from "@/lib/utils";
+import { useNetwork } from "@/lib/providers";
+import { NetworkBadge } from "@/components/common/network-badge";
+import { Link } from "@/i18n/navigation";
+import { Button } from "@/components/ui/button";
+import { ArrowRight } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+function NetworkStats() {
+  const { network } = useNetwork();
+  const { data: ledger, isLoading: ledgerLoading } = useLatestLedger();
+  const { data: feeStats, isLoading: feeLoading } = useFeeStats();
+  const t = useTranslations("stats");
+  const tNetwork = useTranslations("network");
+
+  const avgFee = feeStats?.fee_charged?.mode ? stroopsToXLM(feeStats.fee_charged.mode) : "100";
+
+  const networkLabels = {
+    public: tNetwork("mainnet"),
+    testnet: tNetwork("testnet"),
+    futurenet: tNetwork("futurenet"),
+  };
+
+  const stats = [
+    {
+      title: t("latestLedger"),
+      value: ledger ? formatLedgerSequence(ledger.sequence) : "-",
+      subtitle: ledger ? t("txs", { count: ledger.successful_transaction_count }) : undefined,
+      icon: Layers,
+      loading: ledgerLoading,
+      color: "primary",
+    },
+    {
+      title: t("protocolVersion"),
+      value: ledger?.protocol_version?.toString() || "-",
+      icon: Activity,
+      loading: ledgerLoading,
+      color: "chart-2",
+    },
+    {
+      title: t("baseFee"),
+      value: `${avgFee} XLM`,
+      subtitle: t("perOperation"),
+      icon: Wallet,
+      loading: feeLoading,
+      color: "chart-3",
+    },
+    {
+      title: tNetwork("label"),
+      value: networkLabels[network],
+      icon: TrendingUp,
+      loading: false,
+      color: "chart-4",
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
+      {stats.map((stat, i) => (
+        <Card
+          key={stat.title}
+          variant="glass"
+          className="animate-fade-in-up border-0 py-0"
+          style={{ animationDelay: `${i * 100}ms` }}
+        >
+          <CardContent className="p-4">
+            {stat.loading ? (
+              <div className="space-y-2">
+                <div className="bg-muted/50 h-3 w-20 animate-pulse rounded" />
+                <div className="bg-muted/50 h-7 w-16 animate-pulse rounded" />
+              </div>
+            ) : (
+              <>
+                <div className="text-muted-foreground mb-1 flex items-center gap-2 text-xs">
+                  <stat.icon className="size-3.5" />
+                  {stat.title}
+                </div>
+                <div className="text-2xl font-bold tabular-nums">{stat.value}</div>
+                {stat.subtitle && (
+                  <div className="text-muted-foreground mt-0.5 text-xs">{stat.subtitle}</div>
+                )}
+              </>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function RecentTransactions() {
+  const { data, isLoading } = useRecentTransactions(8);
+  const t = useTranslations("home");
+
+  // Enable real-time transaction streaming
+  useTransactionStream({ enabled: true });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <TransactionCardSkeleton key={i} />
+        ))}
+      </div>
+    );
+  }
+
+  if (!data?.records?.length) {
+    return (
+      <div className="text-muted-foreground py-8 text-center">{t("noRecentTransactions")}</div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {data.records.slice(0, 5).map((tx, i) => (
+        <TransactionCard key={tx.hash} transaction={tx} animationDelay={i * 50} />
+      ))}
+    </div>
+  );
+}
+
+function RecentLedgers() {
+  const { data: latestLedger, isLoading } = useLatestLedger();
+  const t = useTranslations("home");
+
+  if (isLoading || !latestLedger) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <LedgerCardSkeleton key={i} />
+        ))}
+      </div>
+    );
+  }
+
+  // Show just the latest ledger info since we only have one
+  return (
+    <div className="space-y-2">
+      <LedgerCard ledger={latestLedger} />
+      <div className="text-muted-foreground py-4 text-center text-sm">{t("viewAllLedgers")}</div>
+    </div>
+  );
+}
+
+export default function HomePage() {
+  const { network } = useNetwork();
+  const { isConnected: ledgerConnected, error: ledgerError } = useLedgerStream({ enabled: true });
+  const t = useTranslations("home");
+  const tCommon = useTranslations("common");
+  const tExplore = useTranslations("exploreCards");
+
+  // Determine streaming status with disconnected support
+  const streamingStatus = ledgerConnected
+    ? "connected"
+    : ledgerError
+      ? "disconnected"
+      : "connecting";
+
+  return (
+    <div className="space-y-10">
+      {/* Hero section with gradient background */}
+      <section className="relative -mx-4 -mt-4 mb-4 px-4 pt-16 pb-12 md:-mx-6 md:-mt-6 md:px-6 lg:-mx-8 lg:-mt-8 lg:px-8">
+        {/* Gradient overlays */}
+        <div className="from-primary/5 absolute inset-0 bg-gradient-to-b via-transparent to-transparent" />
+        <div className="from-primary/10 absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] via-transparent to-transparent" />
+
+        <div className="relative mx-auto max-w-2xl space-y-6 text-center">
+          <div className="bg-primary/10 border-primary/20 text-primary mb-2 inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm">
+            <Sparkles className="size-3.5" />
+            <span>{t("badge")}</span>
+          </div>
+
+          <h1 className="text-4xl font-bold tracking-tight md:text-5xl">
+            <span className="from-foreground via-foreground to-foreground/60 bg-gradient-to-r bg-clip-text text-transparent">
+              {t("title")}
+            </span>
+          </h1>
+
+          <p className="text-muted-foreground mx-auto max-w-lg text-lg">{t("subtitle")}</p>
+
+          <div className="flex items-center justify-center gap-3">
+            <NetworkBadge network={network} />
+            <LiveIndicator status={streamingStatus} />
+          </div>
+        </div>
+      </section>
+
+      {/* Network Stats */}
+      <section>
+        <div className="mb-5 flex items-center justify-between">
+          <h2 className="text-lg font-semibold">{t("networkOverview")}</h2>
+        </div>
+        <Suspense
+          fallback={
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Card key={i} variant="glass" className="border-0 py-0">
+                  <CardContent className="p-4">
+                    <div className="space-y-2">
+                      <div className="bg-muted/50 h-3 w-20 animate-pulse rounded" />
+                      <div className="bg-muted/50 h-7 w-16 animate-pulse rounded" />
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          }
+        >
+          <NetworkStats />
+        </Suspense>
+      </section>
+
+      {/* Network Activity Charts */}
+      <section>
+        <div className="mb-5 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <BarChart3 className="text-muted-foreground size-5" />
+            <h2 className="text-lg font-semibold">{t("networkActivity")}</h2>
+          </div>
+        </div>
+        <DashboardCharts />
+      </section>
+
+      {/* Network Statistics */}
+      <section>
+        <NetworkStatsCard />
+      </section>
+
+      {/* Two-column layout for transactions and ledgers */}
+      <div className="grid gap-6 md:grid-cols-2">
+        {/* Recent Transactions */}
+        <Card variant="elevated" className="border-0">
+          <CardHeader className="flex flex-row items-center justify-between pb-4">
+            <div className="flex items-center gap-2">
+              <div className="bg-primary/10 flex size-8 items-center justify-center rounded-lg">
+                <Activity className="text-primary size-4" />
+              </div>
+              <CardTitle className="text-base font-semibold">{t("recentTransactions")}</CardTitle>
+            </div>
+            <Button variant="ghost" size="sm" asChild className="hover:bg-white/10">
+              <Link href="/transactions">
+                {tCommon("viewAll")}
+                <ArrowRight className="ml-1 size-4" />
+              </Link>
+            </Button>
+          </CardHeader>
+          <CardContent className="pt-0">
+            <Suspense
+              fallback={
+                <div className="space-y-3">
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <TransactionCardSkeleton key={i} />
+                  ))}
+                </div>
+              }
+            >
+              <RecentTransactions />
+            </Suspense>
+          </CardContent>
+        </Card>
+
+        {/* Recent Ledgers */}
+        <Card variant="elevated" className="border-0">
+          <CardHeader className="flex flex-row items-center justify-between pb-4">
+            <div className="flex items-center gap-2">
+              <div className="bg-chart-1/10 flex size-8 items-center justify-center rounded-lg">
+                <Layers className="text-chart-1 size-4" />
+              </div>
+              <CardTitle className="text-base font-semibold">{t("latestLedger")}</CardTitle>
+            </div>
+            <Button variant="ghost" size="sm" asChild className="hover:bg-white/10">
+              <Link href="/ledgers">
+                {tCommon("viewAll")}
+                <ArrowRight className="ml-1 size-4" />
+              </Link>
+            </Button>
+          </CardHeader>
+          <CardContent className="pt-0">
+            <Suspense
+              fallback={
+                <div className="space-y-3">
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <LedgerCardSkeleton key={i} />
+                  ))}
+                </div>
+              }
+            >
+              <RecentLedgers />
+            </Suspense>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Quick links */}
+      <section>
+        <h2 className="mb-5 text-lg font-semibold">{t("explore")}</h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
+          {[
+            {
+              href: "/transactions",
+              icon: Activity,
+              label: tExplore("transactions"),
+              description: tExplore("transactionsDesc"),
+              color: "primary",
+              bgClass: "bg-primary/10",
+              textClass: "text-primary",
+            },
+            {
+              href: "/ledgers",
+              icon: Layers,
+              label: tExplore("ledgers"),
+              description: tExplore("ledgersDesc"),
+              color: "chart-1",
+              bgClass: "bg-chart-1/10",
+              textClass: "text-chart-1",
+            },
+            {
+              href: "/assets",
+              icon: Wallet,
+              label: tExplore("assets"),
+              description: tExplore("assetsDesc"),
+              color: "chart-3",
+              bgClass: "bg-chart-3/10",
+              textClass: "text-chart-3",
+            },
+            {
+              href: "/contracts",
+              icon: TrendingUp,
+              label: tExplore("contracts"),
+              description: tExplore("contractsDesc"),
+              color: "chart-4",
+              bgClass: "bg-chart-4/10",
+              textClass: "text-chart-4",
+            },
+          ].map((item, i) => (
+            <Link key={item.href} href={item.href}>
+              <Card
+                variant="glass"
+                interactive
+                className="animate-fade-in-up group h-full border-0 py-0"
+                style={{ animationDelay: `${i * 75}ms` }}
+              >
+                <CardContent className="flex flex-col items-center p-5 text-center">
+                  <div
+                    className={`relative size-12 rounded-xl ${item.bgClass} mb-4 flex items-center justify-center transition-transform duration-300 group-hover:scale-110`}
+                  >
+                    {/* Glow effect on hover */}
+                    <div
+                      className={`absolute inset-0 rounded-xl ${item.bgClass} opacity-0 blur-lg transition-opacity duration-300 group-hover:opacity-60`}
+                    />
+                    <item.icon className={`relative size-6 ${item.textClass}`} />
+                  </div>
+                  <span className="mb-1 font-semibold">{item.label}</span>
+                  <span className="text-muted-foreground text-xs">{item.description}</span>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/[locale]/[network]/(explorer)/learn/layout.tsx
+++ b/src/app/[locale]/[network]/(explorer)/learn/layout.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from "next";
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { buildExplorerMetadata } from "@/lib/seo";
 import type { NetworkKey } from "@/types";
@@ -9,22 +9,22 @@ export async function generateMetadata({
   params: Promise<{ locale: string; network: string }>;
 }): Promise<Metadata> {
   const { locale, network } = await params;
-  const t = await getTranslations({ locale, namespace: "assets" });
+  const t = await getTranslations({ locale, namespace: "learn" });
 
   return buildExplorerMetadata({
     locale,
     network: network as NetworkKey,
-    pathname: "/assets",
+    pathname: "/learn",
     title: t("title"),
-    description: t("metaDescription"),
+    description: t("subtitle"),
     openGraph: {
       title: t("title"),
-      description: t("metaDescription"),
+      description: t("subtitle"),
       type: "website",
     },
   });
 }
 
-export default function AssetsLayout({ children }: { children: React.ReactNode }) {
+export default function LearnLayout({ children }: { children: React.ReactNode }) {
   return children;
 }

--- a/src/app/[locale]/[network]/(explorer)/ledger/[sequence]/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/ledger/[sequence]/page.tsx
@@ -1,13 +1,15 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { LedgerContent } from "./ledger-content";
+import { buildExplorerMetadata } from "@/lib/seo";
+import type { NetworkKey } from "@/types";
 
 type Props = {
-  params: Promise<{ sequence: string }>;
+  params: Promise<{ locale: string; network: string; sequence: string }>;
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { sequence } = await params;
+  const { locale, network, sequence } = await params;
   const sequenceNum = parseInt(sequence, 10);
 
   if (isNaN(sequenceNum) || sequenceNum <= 0) {
@@ -18,7 +20,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const formattedSequence = sequenceNum.toLocaleString("en-US");
 
-  return {
+  return buildExplorerMetadata({
+    locale,
+    network: network as NetworkKey,
+    pathname: `/ledger/${sequenceNum}`,
     title: `Ledger #${formattedSequence}`,
     description: `View details of Stellar ledger #${formattedSequence}. Explore transactions, operations, and protocol information.`,
     openGraph: {
@@ -31,7 +36,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title: `Stellar Ledger #${formattedSequence}`,
       description: `View ledger details on Stellar Explorer`,
     },
-  };
+  });
 }
 
 export default async function LedgerPage({ params }: Props) {

--- a/src/app/[locale]/[network]/(explorer)/ledgers/layout.tsx
+++ b/src/app/[locale]/[network]/(explorer)/ledgers/layout.tsx
@@ -1,23 +1,28 @@
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
+import { buildExplorerMetadata } from "@/lib/seo";
+import type { NetworkKey } from "@/types";
 
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ locale: string }>;
+  params: Promise<{ locale: string; network: string }>;
 }): Promise<Metadata> {
-  const { locale } = await params;
+  const { locale, network } = await params;
   const t = await getTranslations({ locale, namespace: "ledgers" });
 
-  return {
-    title: t("metaTitle"),
+  return buildExplorerMetadata({
+    locale,
+    network: network as NetworkKey,
+    pathname: "/ledgers",
+    title: t("title"),
     description: t("metaDescription"),
     openGraph: {
-      title: t("metaTitle"),
+      title: t("title"),
       description: t("metaDescription"),
       type: "website",
     },
-  };
+  });
 }
 
 export default function LedgersLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/[locale]/[network]/(explorer)/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/page.tsx
@@ -1,381 +1,166 @@
-"use client";
-
-import { Suspense } from "react";
-import { Layers, Activity, Wallet, TrendingUp, Sparkles, BarChart3 } from "lucide-react";
-import { DashboardCharts } from "@/components/charts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { TransactionCard, TransactionCardSkeleton } from "@/components/cards/transaction-card";
-import { LedgerCard, LedgerCardSkeleton } from "@/components/cards/ledger-card";
-import { NetworkStatsCard } from "@/components/stats";
-import { LiveIndicator } from "@/components/common/live-indicator";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+import HomePageClient from "./home-page-client";
+import { buildExplorerMetadata } from "@/lib/seo";
 import {
-  useLatestLedger,
-  useRecentTransactions,
-  useFeeStats,
-  useLedgerStream,
-  useTransactionStream,
-} from "@/lib/hooks";
-import { formatLedgerSequence, stroopsToXLM } from "@/lib/utils";
-import { useNetwork } from "@/lib/providers";
-import { NetworkBadge } from "@/components/common/network-badge";
-import { Link } from "@/i18n/navigation";
-import { Button } from "@/components/ui/button";
-import { ArrowRight } from "lucide-react";
-import { useTranslations } from "next-intl";
+  getFeeStatsSnapshot,
+  getLatestLedgerSnapshot,
+  getRecentTransactionsSnapshot,
+} from "@/lib/stellar/server";
+import { formatLedgerSequence, stroopsToXLM, truncateHash } from "@/lib/utils";
+import type { NetworkKey } from "@/types";
 
-function NetworkStats() {
-  const { network } = useNetwork();
-  const { data: ledger, isLoading: ledgerLoading } = useLatestLedger();
-  const { data: feeStats, isLoading: feeLoading } = useFeeStats();
-  const t = useTranslations("stats");
-  const tNetwork = useTranslations("network");
+type Props = {
+  params: Promise<{ locale: string; network: string }>;
+};
 
-  const avgFee = feeStats?.fee_charged?.mode ? stroopsToXLM(feeStats.fee_charged.mode) : "100";
+export const dynamic = "force-dynamic";
 
-  const networkLabels = {
-    public: tNetwork("mainnet"),
-    testnet: tNetwork("testnet"),
-    futurenet: tNetwork("futurenet"),
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale, network } = await params;
+  const t = await getTranslations({ locale, namespace: "home" });
+
+  return buildExplorerMetadata({
+    locale,
+    network: network as NetworkKey,
+    pathname: "",
+    title: "Stellar Blockchain Explorer",
+    description: t("subtitle"),
+    keywords: [
+      "stellar blockchain explorer",
+      "xlm explorer",
+      "stellar transactions",
+      "stellar ledgers",
+      "soroban explorer",
+    ],
+    openGraph: {
+      title: "Stellar Blockchain Explorer",
+      description: t("subtitle"),
+      type: "website",
+    },
+  });
+}
+
+export default async function HomePage({ params }: Props) {
+  const { locale, network } = await params;
+  const typedNetwork = network as NetworkKey;
+
+  const [tHome, tStats] = await Promise.all([
+    getTranslations({ locale, namespace: "home" }),
+    getTranslations({ locale, namespace: "stats" }),
+  ]);
+
+  let latestLedger = null;
+  let feeStats = null;
+  let recentTransactions: Awaited<ReturnType<typeof getRecentTransactionsSnapshot>> = [];
+
+  try {
+    [latestLedger, feeStats, recentTransactions] = await Promise.all([
+      getLatestLedgerSnapshot(typedNetwork),
+      getFeeStatsSnapshot(typedNetwork),
+      getRecentTransactionsSnapshot(typedNetwork, 5),
+    ]);
+  } catch {
+    latestLedger = null;
+    feeStats = null;
+    recentTransactions = [];
+  }
+
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebSite",
+        name: "Stellar Explorer",
+        url: `https://stellar-explorer.acachete.xyz/${locale}/${network}`,
+        description: tHome("subtitle"),
+      },
+      {
+        "@type": "Dataset",
+        name: "Stellar Network Activity Feed",
+        description:
+          "Real-time Stellar blockchain data including ledgers, transactions, accounts, assets, and Soroban contracts.",
+        url: `https://stellar-explorer.acachete.xyz/${locale}/${network}`,
+        creator: {
+          "@type": "Organization",
+          name: "Stellar Explorer",
+        },
+      },
+    ],
   };
 
-  const stats = [
-    {
-      title: t("latestLedger"),
-      value: ledger ? formatLedgerSequence(ledger.sequence) : "-",
-      subtitle: ledger ? t("txs", { count: ledger.successful_transaction_count }) : undefined,
-      icon: Layers,
-      loading: ledgerLoading,
-      color: "primary",
-    },
-    {
-      title: t("protocolVersion"),
-      value: ledger?.protocol_version?.toString() || "-",
-      icon: Activity,
-      loading: ledgerLoading,
-      color: "chart-2",
-    },
-    {
-      title: t("baseFee"),
-      value: `${avgFee} XLM`,
-      subtitle: t("perOperation"),
-      icon: Wallet,
-      loading: feeLoading,
-      color: "chart-3",
-    },
-    {
-      title: tNetwork("label"),
-      value: networkLabels[network],
-      icon: TrendingUp,
-      loading: false,
-      color: "chart-4",
-    },
-  ];
-
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
-      {stats.map((stat, i) => (
-        <Card
-          key={stat.title}
-          variant="glass"
-          className="animate-fade-in-up border-0 py-0"
-          style={{ animationDelay: `${i * 100}ms` }}
-        >
-          <CardContent className="p-4">
-            {stat.loading ? (
-              <div className="space-y-2">
-                <div className="bg-muted/50 h-3 w-20 animate-pulse rounded" />
-                <div className="bg-muted/50 h-7 w-16 animate-pulse rounded" />
-              </div>
-            ) : (
-              <>
-                <div className="text-muted-foreground mb-1 flex items-center gap-2 text-xs">
-                  <stat.icon className="size-3.5" />
-                  {stat.title}
-                </div>
-                <div className="text-2xl font-bold tabular-nums">{stat.value}</div>
-                {stat.subtitle && (
-                  <div className="text-muted-foreground mt-0.5 text-xs">{stat.subtitle}</div>
-                )}
-              </>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <section className="bg-card/40 border-border/60 mb-8 rounded-2xl border px-5 py-5">
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Search Overview</h2>
+          <p className="text-muted-foreground">
+            Stellar Explorer exposes server-rendered blockchain context for crawlers before the
+            interactive dashboard hydrates. This page summarizes live Stellar network activity,
+            recent transactions, current ledger state, and fee conditions.
+          </p>
+          <p className="text-muted-foreground">
+            The current {network} snapshot includes the latest closed ledger, protocol version, and
+            direct links to recent verified Stellar transactions.
+          </p>
+        </div>
+
+        <div className="mt-5 grid gap-4 md:grid-cols-3">
+          <div className="bg-background rounded-xl border p-4">
+            <div className="text-muted-foreground text-xs tracking-wide uppercase">
+              {tStats("latestLedger")}
+            </div>
+            <div className="mt-2 text-2xl font-semibold">
+              {latestLedger ? formatLedgerSequence(latestLedger.sequence) : "-"}
+            </div>
+            {latestLedger && (
+              <p className="text-muted-foreground mt-2 text-sm">
+                {latestLedger.successful_transaction_count} successful transactions in the latest
+                closed ledger.
+              </p>
             )}
-          </CardContent>
-        </Card>
-      ))}
-    </div>
-  );
-}
-
-function RecentTransactions() {
-  const { data, isLoading } = useRecentTransactions(8);
-  const t = useTranslations("home");
-
-  // Enable real-time transaction streaming
-  useTransactionStream({ enabled: true });
-
-  if (isLoading) {
-    return (
-      <div className="space-y-3">
-        {Array.from({ length: 5 }).map((_, i) => (
-          <TransactionCardSkeleton key={i} />
-        ))}
-      </div>
-    );
-  }
-
-  if (!data?.records?.length) {
-    return (
-      <div className="text-muted-foreground py-8 text-center">{t("noRecentTransactions")}</div>
-    );
-  }
-
-  return (
-    <div className="space-y-3">
-      {data.records.slice(0, 5).map((tx, i) => (
-        <TransactionCard key={tx.hash} transaction={tx} animationDelay={i * 50} />
-      ))}
-    </div>
-  );
-}
-
-function RecentLedgers() {
-  const { data: latestLedger, isLoading } = useLatestLedger();
-  const t = useTranslations("home");
-
-  if (isLoading || !latestLedger) {
-    return (
-      <div className="space-y-2">
-        {Array.from({ length: 5 }).map((_, i) => (
-          <LedgerCardSkeleton key={i} />
-        ))}
-      </div>
-    );
-  }
-
-  // Show just the latest ledger info since we only have one
-  return (
-    <div className="space-y-2">
-      <LedgerCard ledger={latestLedger} />
-      <div className="text-muted-foreground py-4 text-center text-sm">{t("viewAllLedgers")}</div>
-    </div>
-  );
-}
-
-export default function HomePage() {
-  const { network } = useNetwork();
-  const { isConnected: ledgerConnected, error: ledgerError } = useLedgerStream({ enabled: true });
-  const t = useTranslations("home");
-  const tCommon = useTranslations("common");
-  const tExplore = useTranslations("exploreCards");
-
-  // Determine streaming status with disconnected support
-  const streamingStatus = ledgerConnected
-    ? "connected"
-    : ledgerError
-      ? "disconnected"
-      : "connecting";
-
-  return (
-    <div className="space-y-10">
-      {/* Hero section with gradient background */}
-      <section className="relative -mx-4 -mt-4 mb-4 px-4 pt-16 pb-12 md:-mx-6 md:-mt-6 md:px-6 lg:-mx-8 lg:-mt-8 lg:px-8">
-        {/* Gradient overlays */}
-        <div className="from-primary/5 absolute inset-0 bg-gradient-to-b via-transparent to-transparent" />
-        <div className="from-primary/10 absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] via-transparent to-transparent" />
-
-        <div className="relative mx-auto max-w-2xl space-y-6 text-center">
-          <div className="bg-primary/10 border-primary/20 text-primary mb-2 inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm">
-            <Sparkles className="size-3.5" />
-            <span>{t("badge")}</span>
           </div>
 
-          <h1 className="text-4xl font-bold tracking-tight md:text-5xl">
-            <span className="from-foreground via-foreground to-foreground/60 bg-gradient-to-r bg-clip-text text-transparent">
-              {t("title")}
-            </span>
-          </h1>
-
-          <p className="text-muted-foreground mx-auto max-w-lg text-lg">{t("subtitle")}</p>
-
-          <div className="flex items-center justify-center gap-3">
-            <NetworkBadge network={network} />
-            <LiveIndicator status={streamingStatus} />
+          <div className="bg-background rounded-xl border p-4">
+            <div className="text-muted-foreground text-xs tracking-wide uppercase">
+              {tStats("protocolVersion")}
+            </div>
+            <div className="mt-2 text-2xl font-semibold">
+              {latestLedger?.protocol_version?.toString() || "-"}
+            </div>
+            <p className="text-muted-foreground mt-2 text-sm">
+              {tStats("baseFee")}:{" "}
+              {feeStats?.fee_charged?.mode ? `${stroopsToXLM(feeStats.fee_charged.mode)} XLM` : "-"}
+            </p>
           </div>
-        </div>
-      </section>
 
-      {/* Network Stats */}
-      <section>
-        <div className="mb-5 flex items-center justify-between">
-          <h2 className="text-lg font-semibold">{t("networkOverview")}</h2>
-        </div>
-        <Suspense
-          fallback={
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
-              {Array.from({ length: 4 }).map((_, i) => (
-                <Card key={i} variant="glass" className="border-0 py-0">
-                  <CardContent className="p-4">
-                    <div className="space-y-2">
-                      <div className="bg-muted/50 h-3 w-20 animate-pulse rounded" />
-                      <div className="bg-muted/50 h-7 w-16 animate-pulse rounded" />
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
+          <div className="bg-background rounded-xl border p-4">
+            <div className="text-muted-foreground text-xs tracking-wide uppercase">
+              Recent Transactions
             </div>
-          }
-        >
-          <NetworkStats />
-        </Suspense>
-      </section>
-
-      {/* Network Activity Charts */}
-      <section>
-        <div className="mb-5 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <BarChart3 className="text-muted-foreground size-5" />
-            <h2 className="text-lg font-semibold">{t("networkActivity")}</h2>
-          </div>
-        </div>
-        <DashboardCharts />
-      </section>
-
-      {/* Network Statistics */}
-      <section>
-        <NetworkStatsCard />
-      </section>
-
-      {/* Two-column layout for transactions and ledgers */}
-      <div className="grid gap-6 md:grid-cols-2">
-        {/* Recent Transactions */}
-        <Card variant="elevated" className="border-0">
-          <CardHeader className="flex flex-row items-center justify-between pb-4">
-            <div className="flex items-center gap-2">
-              <div className="bg-primary/10 flex size-8 items-center justify-center rounded-lg">
-                <Activity className="text-primary size-4" />
-              </div>
-              <CardTitle className="text-base font-semibold">{t("recentTransactions")}</CardTitle>
-            </div>
-            <Button variant="ghost" size="sm" asChild className="hover:bg-white/10">
-              <Link href="/transactions">
-                {tCommon("viewAll")}
-                <ArrowRight className="ml-1 size-4" />
-              </Link>
-            </Button>
-          </CardHeader>
-          <CardContent className="pt-0">
-            <Suspense
-              fallback={
-                <div className="space-y-3">
-                  {Array.from({ length: 5 }).map((_, i) => (
-                    <TransactionCardSkeleton key={i} />
-                  ))}
-                </div>
-              }
-            >
-              <RecentTransactions />
-            </Suspense>
-          </CardContent>
-        </Card>
-
-        {/* Recent Ledgers */}
-        <Card variant="elevated" className="border-0">
-          <CardHeader className="flex flex-row items-center justify-between pb-4">
-            <div className="flex items-center gap-2">
-              <div className="bg-chart-1/10 flex size-8 items-center justify-center rounded-lg">
-                <Layers className="text-chart-1 size-4" />
-              </div>
-              <CardTitle className="text-base font-semibold">{t("latestLedger")}</CardTitle>
-            </div>
-            <Button variant="ghost" size="sm" asChild className="hover:bg-white/10">
-              <Link href="/ledgers">
-                {tCommon("viewAll")}
-                <ArrowRight className="ml-1 size-4" />
-              </Link>
-            </Button>
-          </CardHeader>
-          <CardContent className="pt-0">
-            <Suspense
-              fallback={
-                <div className="space-y-3">
-                  {Array.from({ length: 5 }).map((_, i) => (
-                    <LedgerCardSkeleton key={i} />
-                  ))}
-                </div>
-              }
-            >
-              <RecentLedgers />
-            </Suspense>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Quick links */}
-      <section>
-        <h2 className="mb-5 text-lg font-semibold">{t("explore")}</h2>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
-          {[
-            {
-              href: "/transactions",
-              icon: Activity,
-              label: tExplore("transactions"),
-              description: tExplore("transactionsDesc"),
-              color: "primary",
-              bgClass: "bg-primary/10",
-              textClass: "text-primary",
-            },
-            {
-              href: "/ledgers",
-              icon: Layers,
-              label: tExplore("ledgers"),
-              description: tExplore("ledgersDesc"),
-              color: "chart-1",
-              bgClass: "bg-chart-1/10",
-              textClass: "text-chart-1",
-            },
-            {
-              href: "/assets",
-              icon: Wallet,
-              label: tExplore("assets"),
-              description: tExplore("assetsDesc"),
-              color: "chart-3",
-              bgClass: "bg-chart-3/10",
-              textClass: "text-chart-3",
-            },
-            {
-              href: "/contracts",
-              icon: TrendingUp,
-              label: tExplore("contracts"),
-              description: tExplore("contractsDesc"),
-              color: "chart-4",
-              bgClass: "bg-chart-4/10",
-              textClass: "text-chart-4",
-            },
-          ].map((item, i) => (
-            <Link key={item.href} href={item.href}>
-              <Card
-                variant="glass"
-                interactive
-                className="animate-fade-in-up group h-full border-0 py-0"
-                style={{ animationDelay: `${i * 75}ms` }}
-              >
-                <CardContent className="flex flex-col items-center p-5 text-center">
-                  <div
-                    className={`relative size-12 rounded-xl ${item.bgClass} mb-4 flex items-center justify-center transition-transform duration-300 group-hover:scale-110`}
+            <ul className="mt-2 space-y-2 text-sm">
+              {recentTransactions.map((tx) => (
+                <li key={tx.hash}>
+                  <Link
+                    href={`/${locale}/${network}/tx/${tx.hash}`}
+                    className="text-primary hover:underline"
                   >
-                    {/* Glow effect on hover */}
-                    <div
-                      className={`absolute inset-0 rounded-xl ${item.bgClass} opacity-0 blur-lg transition-opacity duration-300 group-hover:opacity-60`}
-                    />
-                    <item.icon className={`relative size-6 ${item.textClass}`} />
-                  </div>
-                  <span className="mb-1 font-semibold">{item.label}</span>
-                  <span className="text-muted-foreground text-xs">{item.description}</span>
-                </CardContent>
-              </Card>
-            </Link>
-          ))}
+                    {truncateHash(tx.hash, 10, 6)}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
       </section>
-    </div>
+
+      <HomePageClient />
+    </>
   );
 }

--- a/src/app/[locale]/[network]/(explorer)/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/page.tsx
@@ -1,21 +1,12 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import HomePageClient from "./home-page-client";
 import { buildExplorerMetadata } from "@/lib/seo";
-import {
-  getFeeStatsSnapshot,
-  getLatestLedgerSnapshot,
-  getRecentTransactionsSnapshot,
-} from "@/lib/stellar/server";
-import { formatLedgerSequence, stroopsToXLM, truncateHash } from "@/lib/utils";
 import type { NetworkKey } from "@/types";
 
 type Props = {
   params: Promise<{ locale: string; network: string }>;
 };
-
-export const dynamic = "force-dynamic";
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale, network } = await params;
@@ -44,28 +35,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function HomePage({ params }: Props) {
   const { locale, network } = await params;
-  const typedNetwork = network as NetworkKey;
-
-  const [tHome, tStats] = await Promise.all([
-    getTranslations({ locale, namespace: "home" }),
-    getTranslations({ locale, namespace: "stats" }),
-  ]);
-
-  let latestLedger = null;
-  let feeStats = null;
-  let recentTransactions: Awaited<ReturnType<typeof getRecentTransactionsSnapshot>> = [];
-
-  try {
-    [latestLedger, feeStats, recentTransactions] = await Promise.all([
-      getLatestLedgerSnapshot(typedNetwork),
-      getFeeStatsSnapshot(typedNetwork),
-      getRecentTransactionsSnapshot(typedNetwork, 5),
-    ]);
-  } catch {
-    latestLedger = null;
-    feeStats = null;
-    recentTransactions = [];
-  }
+  const tHome = await getTranslations({ locale, namespace: "home" });
 
   const structuredData = {
     "@context": "https://schema.org",
@@ -96,69 +66,6 @@ export default async function HomePage({ params }: Props) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
       />
-
-      <section className="bg-card/40 border-border/60 mb-8 rounded-2xl border px-5 py-5">
-        <div className="space-y-3">
-          <h2 className="text-xl font-semibold">Search Overview</h2>
-          <p className="text-muted-foreground">
-            Stellar Explorer exposes server-rendered blockchain context for crawlers before the
-            interactive dashboard hydrates. This page summarizes live Stellar network activity,
-            recent transactions, current ledger state, and fee conditions.
-          </p>
-          <p className="text-muted-foreground">
-            The current {network} snapshot includes the latest closed ledger, protocol version, and
-            direct links to recent verified Stellar transactions.
-          </p>
-        </div>
-
-        <div className="mt-5 grid gap-4 md:grid-cols-3">
-          <div className="bg-background rounded-xl border p-4">
-            <div className="text-muted-foreground text-xs tracking-wide uppercase">
-              {tStats("latestLedger")}
-            </div>
-            <div className="mt-2 text-2xl font-semibold">
-              {latestLedger ? formatLedgerSequence(latestLedger.sequence) : "-"}
-            </div>
-            {latestLedger && (
-              <p className="text-muted-foreground mt-2 text-sm">
-                {latestLedger.successful_transaction_count} successful transactions in the latest
-                closed ledger.
-              </p>
-            )}
-          </div>
-
-          <div className="bg-background rounded-xl border p-4">
-            <div className="text-muted-foreground text-xs tracking-wide uppercase">
-              {tStats("protocolVersion")}
-            </div>
-            <div className="mt-2 text-2xl font-semibold">
-              {latestLedger?.protocol_version?.toString() || "-"}
-            </div>
-            <p className="text-muted-foreground mt-2 text-sm">
-              {tStats("baseFee")}:{" "}
-              {feeStats?.fee_charged?.mode ? `${stroopsToXLM(feeStats.fee_charged.mode)} XLM` : "-"}
-            </p>
-          </div>
-
-          <div className="bg-background rounded-xl border p-4">
-            <div className="text-muted-foreground text-xs tracking-wide uppercase">
-              Recent Transactions
-            </div>
-            <ul className="mt-2 space-y-2 text-sm">
-              {recentTransactions.map((tx) => (
-                <li key={tx.hash}>
-                  <Link
-                    href={`/${locale}/${network}/tx/${tx.hash}`}
-                    className="text-primary hover:underline"
-                  >
-                    {truncateHash(tx.hash, 10, 6)}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      </section>
 
       <HomePageClient />
     </>

--- a/src/app/[locale]/[network]/(explorer)/search/layout.tsx
+++ b/src/app/[locale]/[network]/(explorer)/search/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { buildExplorerMetadata } from "@/lib/seo";
+import type { NetworkKey } from "@/types";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string; network: string }>;
+}): Promise<Metadata> {
+  const { locale, network } = await params;
+
+  return buildExplorerMetadata({
+    locale,
+    network: network as NetworkKey,
+    pathname: "/search",
+    title: "Search",
+    description: "Search results within Stellar Explorer.",
+    index: false,
+  });
+}
+
+export default function SearchLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/[locale]/[network]/(explorer)/transactions/layout.tsx
+++ b/src/app/[locale]/[network]/(explorer)/transactions/layout.tsx
@@ -1,23 +1,28 @@
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
+import { buildExplorerMetadata } from "@/lib/seo";
+import type { NetworkKey } from "@/types";
 
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ locale: string }>;
+  params: Promise<{ locale: string; network: string }>;
 }): Promise<Metadata> {
-  const { locale } = await params;
+  const { locale, network } = await params;
   const t = await getTranslations({ locale, namespace: "transactions" });
 
-  return {
-    title: t("metaTitle"),
+  return buildExplorerMetadata({
+    locale,
+    network: network as NetworkKey,
+    pathname: "/transactions",
+    title: t("title"),
     description: t("metaDescription"),
     openGraph: {
-      title: t("metaTitle"),
+      title: t("title"),
       description: t("metaDescription"),
       type: "website",
     },
-  };
+  });
 }
 
 export default function TransactionsLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/[locale]/[network]/(explorer)/tx/[hash]/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/tx/[hash]/page.tsx
@@ -1,9 +1,11 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { TransactionContent } from "./transaction-content";
+import { buildExplorerMetadata } from "@/lib/seo";
+import type { NetworkKey } from "@/types";
 
 type Props = {
-  params: Promise<{ hash: string }>;
+  params: Promise<{ locale: string; network: string; hash: string }>;
 };
 
 function isValidTransactionHash(hash: string): boolean {
@@ -11,10 +13,13 @@ function isValidTransactionHash(hash: string): boolean {
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { hash } = await params;
+  const { locale, network, hash } = await params;
   const shortHash = `${hash.slice(0, 8)}...${hash.slice(-8)}`;
 
-  return {
+  return buildExplorerMetadata({
+    locale,
+    network: network as NetworkKey,
+    pathname: `/tx/${hash}`,
     title: `Transaction ${shortHash}`,
     description: `View details of Stellar transaction ${shortHash}. Explore operations, effects, and raw XDR data.`,
     openGraph: {
@@ -27,7 +32,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title: `Stellar Transaction ${shortHash}`,
       description: `View transaction details on Stellar Explorer`,
     },
-  };
+  });
 }
 
 export default async function TransactionPage({ params }: Props) {

--- a/src/app/[locale]/[network]/(explorer)/watchlist/layout.tsx
+++ b/src/app/[locale]/[network]/(explorer)/watchlist/layout.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from "next";
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { buildExplorerMetadata } from "@/lib/seo";
 import type { NetworkKey } from "@/types";
@@ -9,22 +9,18 @@ export async function generateMetadata({
   params: Promise<{ locale: string; network: string }>;
 }): Promise<Metadata> {
   const { locale, network } = await params;
-  const t = await getTranslations({ locale, namespace: "assets" });
+  const t = await getTranslations({ locale, namespace: "watchlist" });
 
   return buildExplorerMetadata({
     locale,
     network: network as NetworkKey,
-    pathname: "/assets",
+    pathname: "/watchlist",
     title: t("title"),
-    description: t("metaDescription"),
-    openGraph: {
-      title: t("title"),
-      description: t("metaDescription"),
-      type: "website",
-    },
+    description: t("subtitle"),
+    index: false,
   });
 }
 
-export default function AssetsLayout({ children }: { children: React.ReactNode }) {
+export default function WatchlistLayout({ children }: { children: React.ReactNode }) {
   return children;
 }

--- a/src/app/[locale]/[network]/layout.tsx
+++ b/src/app/[locale]/[network]/layout.tsx
@@ -1,10 +1,39 @@
 import { notFound } from "next/navigation";
+import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { buildExplorerMetadata, isIndexableNetwork } from "@/lib/seo";
+import type { NetworkKey } from "@/types";
 
 const VALID_NETWORKS = ["public", "testnet", "futurenet"];
 
 export function generateStaticParams() {
   return VALID_NETWORKS.map((network) => ({ network }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string; network: string }>;
+}): Promise<Metadata> {
+  const { locale, network } = await params;
+
+  if (!VALID_NETWORKS.includes(network)) {
+    return {};
+  }
+
+  const typedNetwork = network as NetworkKey;
+  const index = isIndexableNetwork(typedNetwork);
+
+  return buildExplorerMetadata({
+    locale,
+    network: typedNetwork,
+    title: "Stellar Explorer",
+    description:
+      typedNetwork === "public"
+        ? "Explore the Stellar blockchain with server-rendered routes for transactions, ledgers, accounts, assets, and contracts."
+        : `Explore the ${network} Stellar network in a non-indexed environment for testing and developer workflows.`,
+    index,
+  });
 }
 
 export default async function NetworkLayout({

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -7,6 +7,7 @@ import { Analytics } from "@vercel/analytics/next";
 import Script from "next/script";
 import { Providers } from "@/lib/providers";
 import { locales, type Locale } from "@/i18n/config";
+import { getBaseUrl, getLocaleOgTag } from "@/lib/seo";
 import "../globals.css";
 
 const geistSans = Geist({
@@ -35,9 +36,7 @@ export async function generateMetadata({
   const description = t("description");
 
   return {
-    metadataBase: new URL(
-      process.env.NEXT_PUBLIC_BASE_URL || "https://stellar-explorer.acachete.xyz"
-    ),
+    metadataBase: new URL(getBaseUrl()),
     title: {
       default: title,
       template: `%s | ${title}`,
@@ -60,7 +59,7 @@ export async function generateMetadata({
     },
     openGraph: {
       type: "website",
-      locale: locale === "es" ? "es_ES" : "en_US",
+      locale: getLocaleOgTag(locale as Locale),
       siteName: title,
       title: title,
       description: description,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "*",
         allow: "/",
-        disallow: ["/api/", "/watchlist"],
+        disallow: ["/api/", "/*/*/watchlist", "/*/*/search", "/*/*/analytics"],
       },
     ],
     sitemap: "https://stellar-explorer.acachete.xyz/sitemap.xml",

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,14 +1,102 @@
 import { MetadataRoute } from "next";
+import { EXPLORER_STATIC_PATHS, INDEXABLE_NETWORKS, buildExplorerUrl } from "@/lib/seo";
+import { locales } from "@/i18n/config";
+import {
+  getLatestLedgerSnapshot,
+  getRecentTransactionsSnapshot,
+  getTopAssetSnapshots,
+} from "@/lib/stellar/server";
+import { POPULAR_ASSETS } from "@/lib/constants";
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = "https://stellar-explorer.acachete.xyz";
+export const dynamic = "force-dynamic";
 
-  return [
-    { url: baseUrl, priority: 1.0, changeFrequency: "hourly" },
-    { url: `${baseUrl}/transactions`, priority: 0.9, changeFrequency: "always" },
-    { url: `${baseUrl}/ledgers`, priority: 0.9, changeFrequency: "always" },
-    { url: `${baseUrl}/accounts`, priority: 0.8, changeFrequency: "daily" },
-    { url: `${baseUrl}/assets`, priority: 0.8, changeFrequency: "daily" },
-    { url: `${baseUrl}/contracts`, priority: 0.8, changeFrequency: "daily" },
-  ];
+function dedupe<T>(values: T[]): T[] {
+  return [...new Set(values)];
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const staticEntries: MetadataRoute.Sitemap = [];
+
+  for (const locale of locales) {
+    for (const network of INDEXABLE_NETWORKS) {
+      for (const path of EXPLORER_STATIC_PATHS) {
+        staticEntries.push({
+          url: buildExplorerUrl(locale, network, path),
+          priority: path === "" ? 1.0 : 0.8,
+          changeFrequency: path === "" ? "hourly" : "daily",
+        });
+      }
+    }
+  }
+
+  const dynamicEntries = await Promise.all(
+    INDEXABLE_NETWORKS.map(async (network) => {
+      let latestLedger = null;
+      let recentTransactions: Awaited<ReturnType<typeof getRecentTransactionsSnapshot>> = [];
+      let topAssets: Awaited<ReturnType<typeof getTopAssetSnapshots>> = [];
+
+      try {
+        [latestLedger, recentTransactions, topAssets] = await Promise.all([
+          getLatestLedgerSnapshot(network),
+          getRecentTransactionsSnapshot(network, 25),
+          getTopAssetSnapshots(network),
+        ]);
+      } catch {
+        latestLedger = null;
+        recentTransactions = [];
+        topAssets = [];
+      }
+
+      const ledgerEntries: MetadataRoute.Sitemap = latestLedger
+        ? locales.map((locale) => ({
+            url: buildExplorerUrl(locale, network, `/ledger/${latestLedger.sequence}`),
+            lastModified: latestLedger.closed_at,
+            changeFrequency: "hourly",
+            priority: 0.9,
+          }))
+        : [];
+
+      const transactionEntries: MetadataRoute.Sitemap = recentTransactions.flatMap((tx) =>
+        locales.map((locale) => ({
+          url: buildExplorerUrl(locale, network, `/tx/${tx.hash}`),
+          lastModified: tx.created_at,
+          changeFrequency: "hourly",
+          priority: 0.7,
+        }))
+      );
+
+      const accountIds = dedupe(recentTransactions.map((tx) => tx.source_account)).slice(0, 20);
+      const accountEntries: MetadataRoute.Sitemap = accountIds.flatMap((accountId) =>
+        locales.map((locale) => ({
+          url: buildExplorerUrl(locale, network, `/account/${accountId}`),
+          changeFrequency: "daily",
+          priority: 0.6,
+        }))
+      );
+
+      const assetSlugs = dedupe(
+        [...topAssets, ...POPULAR_ASSETS]
+          .map((asset) => {
+            if (!asset) return null;
+            const code = "asset_code" in asset ? asset.asset_code : asset.code;
+            const issuer = "asset_issuer" in asset ? asset.asset_issuer : asset.issuer;
+            if (!code || !issuer) return null;
+            return `${code}-${issuer}`;
+          })
+          .filter((slug): slug is string => slug !== null)
+      );
+
+      const assetEntries: MetadataRoute.Sitemap = assetSlugs.flatMap((slug) =>
+        locales.map((locale) => ({
+          url: buildExplorerUrl(locale, network, `/asset/${slug}`),
+          changeFrequency: "daily",
+          priority: 0.7,
+        }))
+      );
+
+      return [...ledgerEntries, ...transactionEntries, ...accountEntries, ...assetEntries];
+    })
+  );
+
+  return [...staticEntries, ...dynamicEntries.flat()];
 }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,113 @@
+import type { Metadata } from "next";
+import { defaultLocale, locales, type Locale } from "@/i18n/config";
+import type { NetworkKey } from "@/types";
+
+export const INDEXABLE_NETWORKS: NetworkKey[] = ["public"];
+export const NON_INDEXABLE_NETWORKS: NetworkKey[] = ["testnet", "futurenet"];
+export const EXPLORER_STATIC_PATHS = [
+  "",
+  "/transactions",
+  "/ledgers",
+  "/accounts",
+  "/assets",
+  "/contracts",
+  "/learn",
+] as const;
+
+export function getBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_BASE_URL || "https://stellar-explorer.acachete.xyz";
+}
+
+export function isIndexableNetwork(network: NetworkKey): boolean {
+  return INDEXABLE_NETWORKS.includes(network);
+}
+
+export function normalizePath(pathname = ""): string {
+  if (!pathname || pathname === "/") return "";
+  return pathname.startsWith("/") ? pathname : `/${pathname}`;
+}
+
+export function buildExplorerUrl(locale: string, network: string, pathname = ""): string {
+  const path = normalizePath(pathname);
+  return `${getBaseUrl()}/${locale}/${network}${path}`;
+}
+
+export function buildLanguageAlternates(network: string, pathname = ""): Record<string, string> {
+  const path = normalizePath(pathname);
+
+  return Object.fromEntries(
+    locales.map((locale) => [locale, buildExplorerUrl(locale, network, path)])
+  );
+}
+
+export function buildExplorerMetadata({
+  locale,
+  network,
+  pathname,
+  title,
+  description,
+  openGraph,
+  twitter,
+  keywords,
+  index = true,
+}: {
+  locale: string;
+  network: NetworkKey;
+  pathname?: string;
+  title: Metadata["title"];
+  description: string;
+  openGraph?: Metadata["openGraph"];
+  twitter?: Metadata["twitter"];
+  keywords?: Metadata["keywords"];
+  index?: boolean;
+}): Metadata {
+  const shouldIndex = index && isIndexableNetwork(network);
+  const canonical = buildExplorerUrl(locale, network, pathname);
+  const alternates = shouldIndex
+    ? {
+        canonical,
+        languages: {
+          ...buildLanguageAlternates(network, pathname),
+          "x-default": buildExplorerUrl(defaultLocale, network, pathname),
+        },
+      }
+    : {
+        canonical,
+      };
+
+  return {
+    title,
+    description,
+    keywords,
+    alternates,
+    openGraph: {
+      url: canonical,
+      ...openGraph,
+    },
+    twitter,
+    robots: {
+      index: shouldIndex,
+      follow: shouldIndex,
+      googleBot: {
+        index: shouldIndex,
+        follow: shouldIndex,
+      },
+    },
+  };
+}
+
+export function getLocaleOgTag(locale: Locale): string {
+  const localeMap: Record<Locale, string> = {
+    en: "en_US",
+    es: "es_ES",
+    pt: "pt_PT",
+    fr: "fr_FR",
+    de: "de_DE",
+    zh: "zh_CN",
+    ja: "ja_JP",
+    ko: "ko_KR",
+    it: "it_IT",
+  };
+
+  return localeMap[locale];
+}

--- a/src/lib/stellar/server.ts
+++ b/src/lib/stellar/server.ts
@@ -1,0 +1,58 @@
+import { cache } from "react";
+import type { Horizon } from "@stellar/stellar-sdk";
+import { getHorizonClient } from "@/lib/stellar/client";
+import { POPULAR_ASSETS } from "@/lib/constants";
+import type { NetworkKey } from "@/types";
+
+export const getLatestLedgerSnapshot = cache(async (network: NetworkKey) => {
+  const horizon = getHorizonClient(network);
+  const response = await horizon.ledgers().order("desc").limit(1).call();
+  return response.records[0] ?? null;
+});
+
+export const getRecentTransactionsSnapshot = cache(async (network: NetworkKey, limit = 5) => {
+  const horizon = getHorizonClient(network);
+  const response = await horizon.transactions().order("desc").limit(limit).call();
+  return response.records;
+});
+
+export const getFeeStatsSnapshot = cache(async (network: NetworkKey) => {
+  const horizon = getHorizonClient(network);
+  return horizon.feeStats();
+});
+
+export const getTransactionSnapshot = cache(async (network: NetworkKey, hash: string) => {
+  const horizon = getHorizonClient(network);
+  return horizon.transactions().transaction(hash).call();
+});
+
+export const getAccountSnapshot = cache(async (network: NetworkKey, id: string) => {
+  const horizon = getHorizonClient(network);
+  return horizon.accounts().accountId(id).call();
+});
+
+export const getLedgerSnapshot = cache(async (network: NetworkKey, sequence: number) => {
+  const horizon = getHorizonClient(network);
+  const response = await horizon.ledgers().ledger(sequence).call();
+  return response as unknown as Horizon.ServerApi.LedgerRecord;
+});
+
+export const getAssetSnapshot = cache(async (network: NetworkKey, code: string, issuer: string) => {
+  const horizon = getHorizonClient(network);
+  const response = await horizon.assets().forCode(code).forIssuer(issuer).call();
+  return response.records[0] ?? null;
+});
+
+export const getTopAssetSnapshots = cache(async (network: NetworkKey) => {
+  const assets = await Promise.all(
+    POPULAR_ASSETS.map(async (asset) => {
+      try {
+        return await getAssetSnapshot(network, asset.code, asset.issuer);
+      } catch {
+        return null;
+      }
+    })
+  );
+
+  return assets.filter((asset): asset is NonNullable<typeof asset> => asset !== null);
+});


### PR DESCRIPTION
## Summary
This pull request establishes the technical SEO foundation for the explorer so search engines can crawl, interpret, and index the correct routes across the localized and multi-network application structure.

## What Changed
- Added centralized SEO helpers for canonical URLs, language alternates, and network-aware indexability rules
- Aligned route metadata with the real `/{locale}/{network}` URL model
- Marked non-primary networks as non-indexable to avoid duplicate and low-value search exposure
- Rebuilt the sitemap so it emits valid localized explorer URLs and recent dynamic entity routes
- Updated `robots.txt` to keep utility routes out of search discovery
- Added baseline structured data for the homepage
- Introduced server-side snapshot fetching for search-facing content without adding external backend requirements
- Split the homepage into a server-rendered search-facing layer and the existing interactive client dashboard
- Added metadata coverage for accounts, learn, search, watchlist, analytics, and entity detail routes

## Why
Before this change, crawl and canonical signals were not fully aligned with the app’s routing model, and the explorer exposed limited stable HTML for bots on key entry points. This update fixes the indexability gaps while keeping the deployment model fully compatible with Next.js on Vercel.

## Validation
- `bun run lint`
- `bunx tsc --noEmit`
- `bun run build`

## Issue
Closes #24
