### PR TITLE
feat(seo): improve search-facing clarity across explorer sections

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -71,12 +71,15 @@
     "title": "Erkunden Sie das Stellar-Netzwerk",
     "subtitle": "Entdecken Sie Transaktionen, Konten, Assets und Smart Contracts mit einer Premium-Explorer-Erfahrung.",
     "networkOverview": "Netzwerk-Übersicht",
+    "networkOverviewSummary": "Verfolge das neueste Ledger, Gebühren, Protokollversion und das aktive Netzwerk in einer crawlbaren Zusammenfassung.",
     "networkActivity": "Netzwerk-Aktivität",
+    "networkActivitySummary": "Analysiere Muster bei Transaktionen, Operationen, Gebühren und Durchsatz, um die aktuelle Stellar-Aktivität zu verstehen.",
     "recentTransactions": "Kürzliche Transaktionen",
     "latestLedger": "Neuester Ledger",
     "viewAllLedgers": "Alle Ledger für mehr Historie anzeigen",
     "noRecentTransactions": "Keine kürzlichen Transaktionen",
-    "explore": "Erkunden"
+    "explore": "Erkunden",
+    "exploreSummary": "Springe direkt in die wichtigsten Explorer-Bereiche für On-Chain-Aktivität, Ledger-Verlauf, Asset-Entdeckung und Soroban-Vertragsprüfung."
   },
   "stats": {
     "latestLedger": "Neuester Ledger",

--- a/messages/en.json
+++ b/messages/en.json
@@ -68,15 +68,18 @@
   },
   "home": {
     "badge": "Real-time blockchain data",
-    "title": "Explore the Stellar Network",
-    "subtitle": "Discover transactions, accounts, assets, and smart contracts with a premium explorer experience.",
-    "networkOverview": "Network Overview",
-    "networkActivity": "Network Activity",
+    "title": "Stellar blockchain explorer for transactions, accounts, assets, and contracts",
+    "subtitle": "Search Stellar transactions, inspect live ledger activity, and explore accounts, assets, and Soroban smart contracts from one premium explorer.",
+    "networkOverview": "Live Network Overview",
+    "networkOverviewSummary": "Follow the latest ledger, fees, protocol version, and active network environment in a crawlable summary.",
+    "networkActivity": "Network Activity Trends",
+    "networkActivitySummary": "Review transaction, operation, fee, and throughput patterns that explain how the Stellar network is moving right now.",
     "recentTransactions": "Recent Transactions",
     "latestLedger": "Latest Ledger",
     "viewAllLedgers": "View all ledgers for more history",
     "noRecentTransactions": "No recent transactions",
-    "explore": "Explore"
+    "explore": "Explore Stellar Data",
+    "exploreSummary": "Jump directly into the major explorer sections for on-chain activity, ledger history, asset discovery, and Soroban contract inspection."
   },
   "stats": {
     "latestLedger": "Latest Ledger",
@@ -87,27 +90,27 @@
   },
   "exploreCards": {
     "transactions": "Transactions",
-    "transactionsDesc": "View all network activity",
+    "transactionsDesc": "Browse recent Stellar transactions, operations, and status results",
     "ledgers": "Ledgers",
-    "ledgersDesc": "Browse ledger history",
+    "ledgersDesc": "Browse ledger history, close times, and transaction counts",
     "assets": "Assets",
-    "assetsDesc": "Discover tokens",
+    "assetsDesc": "Discover Stellar assets, issuers, holders, and trading signals",
     "contracts": "Contracts",
-    "contractsDesc": "Explore Soroban"
+    "contractsDesc": "Inspect Soroban contracts, events, and verification status"
   },
   "transactions": {
-    "metaTitle": "Transactions | Stellar Explorer",
-    "metaDescription": "Browse recent transactions on the Stellar network. View transaction details, operations, and more.",
-    "title": "Transactions",
+    "metaTitle": "Stellar Transactions | Stellar Explorer",
+    "metaDescription": "Search recent Stellar transactions, inspect operation outcomes, and trace account or ledger activity in one explorer.",
+    "title": "Stellar Transactions",
     "recentTransactions": "Recent Transactions",
     "failedToLoad": "Failed to load transactions",
     "noTransactions": "No transactions",
     "noRecentFound": "No recent transactions found on this network."
   },
   "ledgers": {
-    "metaTitle": "Ledgers | Stellar Explorer",
-    "metaDescription": "Browse ledger history on the Stellar network. Search and explore individual ledgers.",
-    "title": "Ledgers",
+    "metaTitle": "Stellar Ledgers | Stellar Explorer",
+    "metaDescription": "Browse Stellar ledger history, search by sequence, and inspect the latest confirmed ledger activity.",
+    "title": "Stellar Ledgers",
     "searchLedger": "Search Ledger",
     "enterSequence": "Enter ledger sequence number...",
     "enterSequenceError": "Please enter a ledger sequence number",
@@ -119,20 +122,20 @@
     "noLedgersFound": "No ledgers found on this network."
   },
   "accounts": {
-    "title": "Accounts",
-    "subtitle": "Search and explore Stellar accounts",
+    "title": "Stellar Accounts",
+    "subtitle": "Search Stellar accounts, balances, signers, and recent on-chain activity",
     "findAccount": "Find an Account",
     "enterAddress": "Enter account address (G...)",
     "enterAddressError": "Please enter an account address",
     "invalidAddress": "Invalid account address. Must start with G and be 56 characters.",
     "stellarAccounts": "Stellar Accounts",
-    "accountsDescription": "Enter a Stellar address to view account details, balances, transactions, and signing information."
+    "accountsDescription": "Enter a Stellar address to inspect balances, signers, subentries, and recent network activity for any account."
   },
   "assets": {
-    "metaTitle": "Assets | Stellar Explorer",
-    "metaDescription": "Explore assets on the Stellar network. View top assets, search by code or issuer.",
-    "title": "Assets",
-    "subtitle": "Explore tokens and assets on the Stellar network",
+    "metaTitle": "Stellar Assets | Stellar Explorer",
+    "metaDescription": "Explore Stellar assets by code or issuer, compare top tokens, and review holders, supply, and market activity.",
+    "title": "Stellar Assets",
+    "subtitle": "Explore Stellar tokens, issuers, holders, and market activity",
     "findAsset": "Find an Asset",
     "assetCode": "Asset code (e.g., USDC)",
     "issuerAddress": "Issuer address (G...)",
@@ -158,10 +161,10 @@
     "price": "Price"
   },
   "contracts": {
-    "metaTitle": "Smart Contracts | Stellar Explorer",
-    "metaDescription": "Explore Soroban smart contracts on the Stellar network. Search and view contract details.",
-    "title": "Smart Contracts",
-    "subtitle": "Explore Soroban smart contracts on the Stellar network",
+    "metaTitle": "Soroban Smart Contracts | Stellar Explorer",
+    "metaDescription": "Explore Soroban smart contracts on Stellar, search contract IDs, and review events, storage, and verification status.",
+    "title": "Soroban Smart Contracts",
+    "subtitle": "Explore Soroban smart contracts, events, storage, and verification signals",
     "findContract": "Find a Contract",
     "enterContractId": "Enter contract ID (C...)",
     "enterContractIdError": "Please enter a contract ID",

--- a/messages/es.json
+++ b/messages/es.json
@@ -71,12 +71,15 @@
     "title": "Explora la Red Stellar",
     "subtitle": "Descubre transacciones, cuentas, activos y contratos inteligentes con una experiencia de explorador premium.",
     "networkOverview": "Resumen de la red",
+    "networkOverviewSummary": "Sigue el último libro, las comisiones, la versión del protocolo y la red activa en un resumen rastreable.",
     "networkActivity": "Actividad de la red",
+    "networkActivitySummary": "Revisa patrones de transacciones, operaciones, comisiones y rendimiento para entender cómo se mueve Stellar ahora mismo.",
     "recentTransactions": "Transacciones recientes",
     "latestLedger": "Último libro",
     "viewAllLedgers": "Ver todos los libros para más historial",
     "noRecentTransactions": "No hay transacciones recientes",
-    "explore": "Explorar"
+    "explore": "Explorar",
+    "exploreSummary": "Accede directamente a las secciones principales del explorador para actividad on-chain, historial de libros, descubrimiento de activos e inspección de contratos Soroban."
   },
   "stats": {
     "latestLedger": "Último libro",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -71,12 +71,15 @@
     "title": "Explorez le Réseau Stellar",
     "subtitle": "Découvrez les transactions, comptes, actifs et contrats intelligents avec une expérience d'explorateur premium.",
     "networkOverview": "Aperçu du Réseau",
+    "networkOverviewSummary": "Suivez le dernier registre, les frais, la version du protocole et le réseau actif dans un résumé explorable par les moteurs.",
     "networkActivity": "Activité du Réseau",
+    "networkActivitySummary": "Analysez les tendances des transactions, opérations, frais et du débit pour comprendre l'activité actuelle de Stellar.",
     "recentTransactions": "Transactions Récentes",
     "latestLedger": "Dernier Registre",
     "viewAllLedgers": "Voir tous les registres pour plus d'historique",
     "noRecentTransactions": "Aucune transaction récente",
-    "explore": "Explorer"
+    "explore": "Explorer",
+    "exploreSummary": "Accédez directement aux principales sections de l'explorateur pour l'activité on-chain, l'historique des registres, la découverte d'actifs et l'inspection des contrats Soroban."
   },
   "stats": {
     "latestLedger": "Dernier Registre",

--- a/messages/it.json
+++ b/messages/it.json
@@ -71,12 +71,15 @@
     "title": "Esplora la rete Stellar",
     "subtitle": "Scopri transazioni, conti, risorse e smart contract con un'esperienza di esplorazione premium.",
     "networkOverview": "Panoramica della rete",
+    "networkOverviewSummary": "Segui l'ultimo registro, le commissioni, la versione del protocollo e la rete attiva in un riepilogo indicizzabile.",
     "networkActivity": "Attività di rete",
+    "networkActivitySummary": "Analizza andamenti di transazioni, operazioni, commissioni e throughput per capire come si muove Stellar in questo momento.",
     "recentTransactions": "Transazioni recenti",
     "latestLedger": "Ultimo registro",
     "viewAllLedgers": "Visualizza tutti i registri per più cronologia",
     "noRecentTransactions": "Nessuna transazione recente",
-    "explore": "Esplora"
+    "explore": "Esplora",
+    "exploreSummary": "Accedi direttamente alle principali sezioni dell'explorer per attività on-chain, cronologia dei registri, scoperta degli asset e ispezione dei contratti Soroban."
   },
   "stats": {
     "latestLedger": "Ultimo registro",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -71,12 +71,15 @@
     "title": "Stellar ネットワークを探索",
     "subtitle": "プレミアムエクスプローラー体験でトランザクション、アカウント、アセット、スマートコントラクトを発見。",
     "networkOverview": "ネットワーク概要",
+    "networkOverviewSummary": "最新レジャー、手数料、プロトコルバージョン、現在のネットワーク環境をクロールしやすい要約で確認できます。",
     "networkActivity": "ネットワーク活動",
+    "networkActivitySummary": "トランザクション、オペレーション、手数料、スループットの傾向を見て、現在の Stellar の動きを把握できます。",
     "recentTransactions": "最近のトランザクション",
     "latestLedger": "最新レジャー",
     "viewAllLedgers": "履歴を見るにはすべてのレジャーを表示",
     "noRecentTransactions": "最近のトランザクションはありません",
-    "explore": "探索"
+    "explore": "探索",
+    "exploreSummary": "オンチェーン活動、レジャー履歴、資産探索、Soroban コントラクトの確認に直接アクセスできます。"
   },
   "stats": {
     "latestLedger": "最新レジャー",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -71,12 +71,15 @@
     "title": "Stellar 네트워크 탐색",
     "subtitle": "프리미엄 익스플로러 경험으로 트랜잭션, 계정, 자산 및 스마트 컨트랙트를 발견하세요.",
     "networkOverview": "네트워크 개요",
+    "networkOverviewSummary": "크롤링 가능한 요약으로 최신 원장, 수수료, 프로토콜 버전, 현재 네트워크 환경을 확인하세요.",
     "networkActivity": "네트워크 활동",
+    "networkActivitySummary": "거래, 작업, 수수료, 처리량 추세를 검토해 현재 Stellar 네트워크 움직임을 파악하세요.",
     "recentTransactions": "최근 트랜잭션",
     "latestLedger": "최신 원장",
     "viewAllLedgers": "더 많은 원장 기록 보기",
     "noRecentTransactions": "최근 트랜잭션 없음",
-    "explore": "탐색"
+    "explore": "탐색",
+    "exploreSummary": "온체인 활동, 원장 기록, 자산 탐색, Soroban 계약 점검을 위해 주요 익스플로러 섹션으로 바로 이동하세요."
   },
   "stats": {
     "latestLedger": "최신 원장",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -71,12 +71,15 @@
     "title": "Explore a Rede Stellar",
     "subtitle": "Descubra transações, contas, ativos e contratos inteligentes com uma experiência de explorador premium.",
     "networkOverview": "Visão Geral da Rede",
+    "networkOverviewSummary": "Acompanhe o livro mais recente, as taxas, a versão do protocolo e a rede ativa em um resumo rastreável.",
     "networkActivity": "Atividade da Rede",
+    "networkActivitySummary": "Revise padrões de transações, operações, taxas e throughput para entender como a Stellar está se movendo agora.",
     "recentTransactions": "Transações Recentes",
     "latestLedger": "Último Livro",
     "viewAllLedgers": "Ver todos os livros para mais histórico",
     "noRecentTransactions": "Nenhuma transação recente",
-    "explore": "Explorar"
+    "explore": "Explorar",
+    "exploreSummary": "Acesse rapidamente as principais seções do explorador para atividade on-chain, histórico de livros, descoberta de ativos e inspeção de contratos Soroban."
   },
   "stats": {
     "latestLedger": "Último Livro",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -71,12 +71,15 @@
     "title": "探索 Stellar 网络",
     "subtitle": "通过高级浏览器体验发现交易、账户、资产和智能合约。",
     "networkOverview": "网络概览",
+    "networkOverviewSummary": "通过可抓取的摘要跟踪最新账本、费用、协议版本和当前网络环境。",
     "networkActivity": "网络活动",
+    "networkActivitySummary": "查看交易、操作、费用和吞吐趋势，更清楚地理解 Stellar 当前的网络动态。",
     "recentTransactions": "最近交易",
     "latestLedger": "最新账本",
     "viewAllLedgers": "查看所有账本以获取更多历史",
     "noRecentTransactions": "没有最近交易",
-    "explore": "探索"
+    "explore": "探索",
+    "exploreSummary": "直接进入浏览器的主要部分，查看链上活动、账本历史、资产发现和 Soroban 合约检查。"
   },
   "stats": {
     "latestLedger": "最新账本",

--- a/src/app/[locale]/[network]/(explorer)/accounts/layout.tsx
+++ b/src/app/[locale]/[network]/(explorer)/accounts/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { buildExplorerMetadata } from "@/lib/seo";
+import { StructuredDataScript } from "@/components/common";
+import { buildCollectionPageStructuredData, buildExplorerMetadata } from "@/lib/seo";
 import type { NetworkKey } from "@/types";
 
 export async function generateMetadata({
@@ -17,6 +18,12 @@ export async function generateMetadata({
     pathname: "/accounts",
     title: t("title"),
     description: t("subtitle"),
+    keywords: [
+      "stellar accounts",
+      "stellar address lookup",
+      "stellar account balances",
+      "stellar account explorer",
+    ],
     openGraph: {
       title: t("title"),
       description: t("subtitle"),
@@ -25,6 +32,29 @@ export async function generateMetadata({
   });
 }
 
-export default function AccountsLayout({ children }: { children: React.ReactNode }) {
-  return children;
+export default async function AccountsLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string; network: string }>;
+}) {
+  const { locale, network } = await params;
+  const t = await getTranslations({ locale, namespace: "accounts" });
+
+  return (
+    <>
+      <StructuredDataScript
+        data={buildCollectionPageStructuredData({
+          locale,
+          network,
+          pathname: "/accounts",
+          name: t("title"),
+          description: t("subtitle"),
+          about: ["Stellar accounts", "account lookup", "account balances", "account signers"],
+        })}
+      />
+      {children}
+    </>
+  );
 }

--- a/src/app/[locale]/[network]/(explorer)/accounts/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/accounts/page.tsx
@@ -2,6 +2,7 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PageHeader } from "@/components/layout/page-header";
+import { SearchContextPanel } from "@/components/common/search-context-panel";
 import { useNetwork } from "@/lib/providers";
 import { NetworkBadge } from "@/components/common/network-badge";
 import { Users, Search } from "lucide-react";
@@ -19,6 +20,7 @@ export default function AccountsPage() {
   const [error, setError] = useState("");
   const t = useTranslations("accounts");
   const tCommon = useTranslations("common");
+  const tAccount = useTranslations("account");
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
@@ -42,6 +44,16 @@ export default function AccountsPage() {
         backLabel={tCommon("home")}
         showCopy={false}
         badge={<NetworkBadge network={network} />}
+      />
+
+      <SearchContextPanel
+        description={t("accountsDescription")}
+        highlights={[
+          t("findAccount"),
+          t("stellarAccounts"),
+          tAccount("balances"),
+          tAccount("signers"),
+        ]}
       />
 
       {/* Search for an account */}

--- a/src/app/[locale]/[network]/(explorer)/assets/layout.tsx
+++ b/src/app/[locale]/[network]/(explorer)/assets/layout.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { buildExplorerMetadata } from "@/lib/seo";
+import { StructuredDataScript } from "@/components/common";
+import { buildCollectionPageStructuredData, buildExplorerMetadata } from "@/lib/seo";
 import type { NetworkKey } from "@/types";
 
 export async function generateMetadata({
@@ -17,6 +18,12 @@ export async function generateMetadata({
     pathname: "/assets",
     title: t("title"),
     description: t("metaDescription"),
+    keywords: [
+      "stellar assets",
+      "stellar tokens",
+      "stellar asset explorer",
+      "stellar issuer lookup",
+    ],
     openGraph: {
       title: t("title"),
       description: t("metaDescription"),
@@ -25,6 +32,29 @@ export async function generateMetadata({
   });
 }
 
-export default function AssetsLayout({ children }: { children: React.ReactNode }) {
-  return children;
+export default async function AssetsLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string; network: string }>;
+}) {
+  const { locale, network } = await params;
+  const t = await getTranslations({ locale, namespace: "assets" });
+
+  return (
+    <>
+      <StructuredDataScript
+        data={buildCollectionPageStructuredData({
+          locale,
+          network,
+          pathname: "/assets",
+          name: t("title"),
+          description: t("metaDescription"),
+          about: ["Stellar assets", "asset search", "asset issuers", "token holders"],
+        })}
+      />
+      {children}
+    </>
+  );
 }

--- a/src/app/[locale]/[network]/(explorer)/assets/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/assets/page.tsx
@@ -11,6 +11,7 @@ import { PageHeader } from "@/components/layout/page-header";
 import { AssetLogo } from "@/components/common/asset-logo";
 import { AssetTable, AssetTableSkeleton, type AssetData } from "@/components/assets";
 import { ErrorState } from "@/components/common/error-state";
+import { SearchContextPanel } from "@/components/common/search-context-panel";
 import { useNetwork } from "@/lib/providers";
 import { NetworkBadge } from "@/components/common/network-badge";
 import { useTopAssets, useAssetsList } from "@/lib/hooks";
@@ -253,6 +254,11 @@ export default function AssetsPage() {
         backLabel={tCommon("home")}
         showCopy={false}
         badge={<NetworkBadge network={network} />}
+      />
+
+      <SearchContextPanel
+        description={t("metaDescription")}
+        highlights={[t("findAsset"), t("popularAssets"), t("topAssets"), t("allAssets")]}
       />
 
       {/* Search Form */}

--- a/src/app/[locale]/[network]/(explorer)/contracts/layout.tsx
+++ b/src/app/[locale]/[network]/(explorer)/contracts/layout.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { buildExplorerMetadata } from "@/lib/seo";
+import { StructuredDataScript } from "@/components/common";
+import { buildCollectionPageStructuredData, buildExplorerMetadata } from "@/lib/seo";
 import type { NetworkKey } from "@/types";
 
 export async function generateMetadata({
@@ -17,6 +18,12 @@ export async function generateMetadata({
     pathname: "/contracts",
     title: t("title"),
     description: t("metaDescription"),
+    keywords: [
+      "soroban contracts",
+      "stellar smart contracts",
+      "soroban explorer",
+      "contract events",
+    ],
     openGraph: {
       title: t("title"),
       description: t("metaDescription"),
@@ -25,6 +32,29 @@ export async function generateMetadata({
   });
 }
 
-export default function ContractsLayout({ children }: { children: React.ReactNode }) {
-  return children;
+export default async function ContractsLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string; network: string }>;
+}) {
+  const { locale, network } = await params;
+  const t = await getTranslations({ locale, namespace: "contracts" });
+
+  return (
+    <>
+      <StructuredDataScript
+        data={buildCollectionPageStructuredData({
+          locale,
+          network,
+          pathname: "/contracts",
+          name: t("title"),
+          description: t("metaDescription"),
+          about: ["Soroban contracts", "smart contracts", "contract events", "contract verification"],
+        })}
+      />
+      {children}
+    </>
+  );
 }

--- a/src/app/[locale]/[network]/(explorer)/contracts/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/contracts/page.tsx
@@ -3,6 +3,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PageHeader } from "@/components/layout/page-header";
 import { EmptyState } from "@/components/common/empty-state";
+import { SearchContextPanel } from "@/components/common/search-context-panel";
 import { useNetwork } from "@/lib/providers";
 import { NetworkBadge } from "@/components/common/network-badge";
 import { FileCode, ExternalLink, Search } from "lucide-react";
@@ -20,6 +21,7 @@ export default function ContractsPage() {
   const [error, setError] = useState("");
   const t = useTranslations("contracts");
   const tCommon = useTranslations("common");
+  const tContract = useTranslations("contract");
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
@@ -43,6 +45,16 @@ export default function ContractsPage() {
         backLabel={tCommon("home")}
         showCopy={false}
         badge={<NetworkBadge network={network} />}
+      />
+
+      <SearchContextPanel
+        description={t("contractsDescription")}
+        highlights={[
+          t("findContract"),
+          t("sorobanContracts"),
+          tContract("events"),
+          t("learnSoroban"),
+        ]}
       />
 
       {/* Search for a contract */}

--- a/src/app/[locale]/[network]/(explorer)/home-page-client.tsx
+++ b/src/app/[locale]/[network]/(explorer)/home-page-client.tsx
@@ -8,6 +8,7 @@ import { TransactionCard, TransactionCardSkeleton } from "@/components/cards/tra
 import { LedgerCard, LedgerCardSkeleton } from "@/components/cards/ledger-card";
 import { NetworkStatsCard } from "@/components/stats";
 import { LiveIndicator } from "@/components/common/live-indicator";
+import { SearchContextPanel } from "@/components/common/search-context-panel";
 import {
   useLatestLedger,
   useRecentTransactions,
@@ -203,10 +204,23 @@ export default function HomePage() {
         </div>
       </section>
 
+      <SearchContextPanel
+        description={t("subtitle")}
+        highlights={[
+          t("networkOverview"),
+          t("networkActivity"),
+          tExplore("transactionsDesc"),
+          tExplore("contractsDesc"),
+        ]}
+      />
+
       {/* Network Stats */}
       <section>
         <div className="mb-5 flex items-center justify-between">
-          <h2 className="text-lg font-semibold">{t("networkOverview")}</h2>
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold">{t("networkOverview")}</h2>
+            <p className="text-muted-foreground text-sm">{t("networkOverviewSummary")}</p>
+          </div>
         </div>
         <Suspense
           fallback={
@@ -231,9 +245,12 @@ export default function HomePage() {
       {/* Network Activity Charts */}
       <section>
         <div className="mb-5 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <BarChart3 className="text-muted-foreground size-5" />
-            <h2 className="text-lg font-semibold">{t("networkActivity")}</h2>
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <BarChart3 className="text-muted-foreground size-5" />
+              <h2 className="text-lg font-semibold">{t("networkActivity")}</h2>
+            </div>
+            <p className="text-muted-foreground text-sm">{t("networkActivitySummary")}</p>
           </div>
         </div>
         <DashboardCharts />
@@ -311,7 +328,10 @@ export default function HomePage() {
 
       {/* Quick links */}
       <section>
-        <h2 className="mb-5 text-lg font-semibold">{t("explore")}</h2>
+        <div className="mb-5 space-y-1">
+          <h2 className="text-lg font-semibold">{t("explore")}</h2>
+          <p className="text-muted-foreground text-sm">{t("exploreSummary")}</p>
+        </div>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
           {[
             {

--- a/src/app/[locale]/[network]/(explorer)/ledgers/layout.tsx
+++ b/src/app/[locale]/[network]/(explorer)/ledgers/layout.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { buildExplorerMetadata } from "@/lib/seo";
+import { StructuredDataScript } from "@/components/common";
+import { buildCollectionPageStructuredData, buildExplorerMetadata } from "@/lib/seo";
 import type { NetworkKey } from "@/types";
 
 export async function generateMetadata({
@@ -17,6 +18,12 @@ export async function generateMetadata({
     pathname: "/ledgers",
     title: t("title"),
     description: t("metaDescription"),
+    keywords: [
+      "stellar ledgers",
+      "stellar ledger explorer",
+      "ledger sequence search",
+      "stellar ledger history",
+    ],
     openGraph: {
       title: t("title"),
       description: t("metaDescription"),
@@ -25,6 +32,29 @@ export async function generateMetadata({
   });
 }
 
-export default function LedgersLayout({ children }: { children: React.ReactNode }) {
-  return children;
+export default async function LedgersLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string; network: string }>;
+}) {
+  const { locale, network } = await params;
+  const t = await getTranslations({ locale, namespace: "ledgers" });
+
+  return (
+    <>
+      <StructuredDataScript
+        data={buildCollectionPageStructuredData({
+          locale,
+          network,
+          pathname: "/ledgers",
+          name: t("title"),
+          description: t("metaDescription"),
+          about: ["Stellar ledgers", "ledger search", "ledger history", "ledger sequence"],
+        })}
+      />
+      {children}
+    </>
+  );
 }

--- a/src/app/[locale]/[network]/(explorer)/ledgers/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/ledgers/page.tsx
@@ -9,6 +9,7 @@ import { PageHeader } from "@/components/layout/page-header";
 import { LedgerCard, LedgerCardSkeleton } from "@/components/cards/ledger-card";
 import { EmptyState } from "@/components/common/empty-state";
 import { ErrorState } from "@/components/common/error-state";
+import { SearchContextPanel } from "@/components/common/search-context-panel";
 import { useLatestLedger } from "@/lib/hooks";
 import { useNetwork } from "@/lib/providers";
 import { NetworkBadge } from "@/components/common/network-badge";
@@ -24,6 +25,7 @@ export default function LedgersPage() {
   const { data: latestLedger, isLoading, error, refetch } = useLatestLedger();
   const t = useTranslations("ledgers");
   const tCommon = useTranslations("common");
+  const tStats = useTranslations("stats");
 
   const [ledgerSequence, setLedgerSequence] = useState("");
   const [searchError, setSearchError] = useState("");
@@ -56,10 +58,21 @@ export default function LedgersPage() {
     <div className="space-y-6">
       <PageHeader
         title={t("title")}
+        subtitle={t("metaDescription")}
         backHref="/"
         backLabel={tCommon("home")}
         showCopy={false}
         badge={<NetworkBadge network={network} />}
+      />
+
+      <SearchContextPanel
+        description={t("metaDescription")}
+        highlights={[
+          t("searchLedger"),
+          t("recentLedgers"),
+          tStats("latestLedger"),
+          tCommon("search"),
+        ]}
       />
 
       {/* Search Form */}

--- a/src/app/[locale]/[network]/(explorer)/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import HomePageClient from "./home-page-client";
 import { buildExplorerMetadata } from "@/lib/seo";
+import { StructuredDataScript } from "@/components/common";
 import type { NetworkKey } from "@/types";
 
 type Props = {
@@ -22,8 +23,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       "stellar blockchain explorer",
       "xlm explorer",
       "stellar transactions",
+      "stellar accounts",
+      "stellar assets",
       "stellar ledgers",
       "soroban explorer",
+      "soroban contracts",
     ],
     openGraph: {
       title: "Stellar Blockchain Explorer",
@@ -62,10 +66,7 @@ export default async function HomePage({ params }: Props) {
 
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
-      />
+      <StructuredDataScript data={structuredData} />
 
       <HomePageClient />
     </>

--- a/src/app/[locale]/[network]/(explorer)/transactions/layout.tsx
+++ b/src/app/[locale]/[network]/(explorer)/transactions/layout.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { buildExplorerMetadata } from "@/lib/seo";
+import { StructuredDataScript } from "@/components/common";
+import { buildCollectionPageStructuredData, buildExplorerMetadata } from "@/lib/seo";
 import type { NetworkKey } from "@/types";
 
 export async function generateMetadata({
@@ -17,6 +18,12 @@ export async function generateMetadata({
     pathname: "/transactions",
     title: t("title"),
     description: t("metaDescription"),
+    keywords: [
+      "stellar transactions",
+      "stellar transaction search",
+      "stellar account activity",
+      "stellar ledger transactions",
+    ],
     openGraph: {
       title: t("title"),
       description: t("metaDescription"),
@@ -25,6 +32,29 @@ export async function generateMetadata({
   });
 }
 
-export default function TransactionsLayout({ children }: { children: React.ReactNode }) {
-  return children;
+export default async function TransactionsLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string; network: string }>;
+}) {
+  const { locale, network } = await params;
+  const t = await getTranslations({ locale, namespace: "transactions" });
+
+  return (
+    <>
+      <StructuredDataScript
+        data={buildCollectionPageStructuredData({
+          locale,
+          network,
+          pathname: "/transactions",
+          name: t("title"),
+          description: t("metaDescription"),
+          about: ["Stellar transactions", "transaction search", "ledger activity", "account activity"],
+        })}
+      />
+      {children}
+    </>
+  );
 }

--- a/src/app/[locale]/[network]/(explorer)/transactions/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/transactions/page.tsx
@@ -8,6 +8,7 @@ import { PageHeader } from "@/components/layout/page-header";
 import { TransactionCard, TransactionCardSkeleton } from "@/components/cards/transaction-card";
 import { EmptyState } from "@/components/common/empty-state";
 import { ErrorState } from "@/components/common/error-state";
+import { SearchContextPanel } from "@/components/common/search-context-panel";
 import {
   TransactionSearch,
   TransactionFilters,
@@ -131,10 +132,21 @@ export default function TransactionsPage() {
     <div className="space-y-6">
       <PageHeader
         title={t("title")}
+        subtitle={t("metaDescription")}
         backHref="/"
         backLabel={tCommon("home")}
         showCopy={false}
         badge={<NetworkBadge network={network} />}
+      />
+
+      <SearchContextPanel
+        description={t("metaDescription")}
+        highlights={[
+          t("recentTransactions"),
+          tSearch("accountLabel"),
+          tSearch("ledgerLabel"),
+          tSearch("filterByStatus"),
+        ]}
       />
 
       {/* Search Form */}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -12,3 +12,5 @@ export * from "./copy-button";
 export * from "./breadcrumbs";
 export * from "./live-indicator";
 export * from "./asset-logo";
+export * from "./search-context-panel";
+export * from "./structured-data-script";

--- a/src/components/common/search-context-panel.tsx
+++ b/src/components/common/search-context-panel.tsx
@@ -1,0 +1,38 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface SearchContextPanelProps {
+  description: string;
+  highlights: string[];
+  className?: string;
+}
+
+export function SearchContextPanel({
+  description,
+  highlights,
+  className,
+}: SearchContextPanelProps) {
+  return (
+    <section aria-label={description} className={className}>
+      <Card variant="gradient" className="border-0 py-0">
+        <CardContent className="grid gap-5 p-5 md:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)] md:p-6">
+          <p className="text-muted-foreground text-sm leading-6 md:text-base">{description}</p>
+
+          <ul className="grid gap-2 sm:grid-cols-2 md:grid-cols-1">
+            {highlights.map((highlight) => (
+              <li
+                key={highlight}
+                className={cn(
+                  "bg-background/70 border-border/70 rounded-xl border px-3 py-2 text-sm font-medium",
+                  "backdrop-blur-sm"
+                )}
+              >
+                {highlight}
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/src/components/common/structured-data-script.tsx
+++ b/src/components/common/structured-data-script.tsx
@@ -1,0 +1,12 @@
+interface StructuredDataScriptProps {
+  data: Record<string, unknown>;
+}
+
+export function StructuredDataScript({ data }: StructuredDataScriptProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -96,6 +96,42 @@ export function buildExplorerMetadata({
   };
 }
 
+export function buildCollectionPageStructuredData({
+  locale,
+  network,
+  pathname,
+  name,
+  description,
+  about = [],
+}: {
+  locale: string;
+  network: string;
+  pathname: string;
+  name: string;
+  description: string;
+  about?: string[];
+}) {
+  const url = buildExplorerUrl(locale, network, pathname);
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name,
+    description,
+    url,
+    inLanguage: locale,
+    isPartOf: {
+      "@type": "WebSite",
+      name: "Stellar Explorer",
+      url: buildExplorerUrl(locale, network),
+    },
+    about: about.map((term) => ({
+      "@type": "Thing",
+      name: term,
+    })),
+  };
+}
+
 export function getLocaleOgTag(locale: Locale): string {
   const localeMap: Record<Locale, string> = {
     en: "en_US",


### PR DESCRIPTION
## Summary
- strengthen search-facing clarity on the homepage and major explorer index sections without diluting the premium product experience
- add reusable semantic context panels and collection-page structured data for homepage, transactions, ledgers, accounts, assets, and contracts
- refine metadata and English copy to better express search intent, and add the new homepage copy keys across all locales to keep translations aligned

## Why
This issue is about improving discoverability and semantic clarity while preserving the explorer's visual quality. The implementation keeps the UI product-led, avoids dumping long SEO copy blocks into the layout, and moves the added context into concise, design-integrated panels plus server-rendered metadata and JSON-LD.

## Validation
- verified translation files keep matching key counts after adding the new homepage copy keys
- validated modified JSON files with `jq empty`
- validated the patch with `git diff --check`
- full `build`, `lint`, and `format:check` were not runnable locally in this workspace because dependencies are not installed

Closes #25