### PR TITLE
feat(seo): enrich entity detail pages with contextual summaries

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -256,7 +256,12 @@
     "noTransactions": "Keine Transaktionen verfügbar",
     "noTransactionsDesc": "Entschuldigung, unsere aktuelle Infrastruktur speichert nur etwa 7 Tage an Transaktionsdaten. Wir bauen aktiv einen Indexer, der den vollständigen Transaktionsverlauf, detaillierte Event-Daten und eine vollständige Blockchain-Abdeckung ermöglichen wird.",
     "lastActivity": "Letzte Aktivität",
-    "contractTransactions": "Transaktionen"
+    "contractTransactions": "Transaktionen",
+    "contextTitle": "Kontext des Vertrags",
+    "contextWasmSummary": "Dieser Vertrag ist als benutzerdefinierter Soroban-WASM-Code bereitgestellt und stellt derzeit {storage} Instanzspeichereinträge bereit.",
+    "contextSacSummary": "Dieser Vertrag ist ein Stellar Asset Contract-Wrapper und folgt daher der Standard-Schnittstelle des Assets statt benutzerdefiniertem WASM-Bytecode.",
+    "contextStorageDetail": "Die aktuelle Speicher-TTL beträgt etwa {ttl} Ledger.",
+    "contextNoStorageDetail": "Derzeit sind keine Instanzspeichereinträge sichtbar."
   },
   "watchlist": {
     "title": "Merkliste",
@@ -286,7 +291,12 @@
     "failedToLoadOps": "Operationen konnten nicht geladen werden",
     "failedToLoadEffects": "Effekte konnten nicht geladen werden",
     "envelopeXdr": "Envelope XDR",
-    "resultXdr": "Result XDR"
+    "resultXdr": "Result XDR",
+    "contextTitle": "Was passiert ist",
+    "contextSuccessSummary": "Diese Transaktion wurde in Ledger #{ledger} mit {operations} Operationen aufgenommen und zahlte {fee} XLM von {source}.",
+    "contextFailedSummary": "Diese Transaktion ist in Ledger #{ledger} nach {operations} versuchten Operationen fehlgeschlagen; berechnet wurden {fee} XLM Gebühren von {source}.",
+    "contextMemoDetail": "Ein Memo wurde angehängt: {memo}.",
+    "contextNoMemoDetail": "Dieser Transaktion wurde kein Memo angehängt."
   },
   "account": {
     "title": "Konto",
@@ -315,7 +325,11 @@
     "limit": "Limit:",
     "max": "Max",
     "sorobanCall": "Soroban-Vertragsaufruf",
-    "weight": "Gewicht: {weight}"
+    "weight": "Gewicht: {weight}",
+    "contextTitle": "Kontokontext",
+    "contextSummary": "Dieses Konto hält derzeit {xlm} XLM, verfolgt {assets} nicht-native Assets und verwendet {signers} Signatur(en) über {subentries} Untereinträge.",
+    "contextHomeDomainDetail": "Die angegebene Home-Domain ist {domain}.",
+    "contextNoHomeDomainDetail": "Für dieses Konto ist keine Home-Domain angegeben."
   },
   "operations": {
     "create_account": "Konto erstellen",
@@ -571,7 +585,12 @@
     "xlmPurpose1": "Transaktionsgebühren bezahlen (typischerweise 0.00001 XLM pro Operation)",
     "xlmPurpose2": "Mindestkontostände aufrechterhalten (Basisreserve)",
     "xlmPurpose3": "Spam verhindern durch Anforderung kleiner Beträge für Kontoerstellung",
-    "xlmPurpose4": "Brückenwährung für Asset-übergreifende Transaktionen über DEX"
+    "xlmPurpose4": "Brückenwährung für Asset-übergreifende Transaktionen über DEX",
+    "contextTitle": "Asset-Kontext",
+    "contextOpenSummary": "{asset} wird von {issuer} emittiert, mit {holders} haltenden Konten und einem geschätzten Angebot von {supply}. Der Zugriff für Trustlines und Transfers ist derzeit offen.",
+    "contextRestrictedSummary": "{asset} wird von {issuer} emittiert, mit {holders} haltenden Konten und einem geschätzten Angebot von {supply}. Emittentenkontrollen wie Autorisierung oder Widerruf sind aktiviert.",
+    "contextOrgDetail": "{org} veröffentlicht die zu diesem Asset gehörenden Stellar-Metadaten.",
+    "contextNoOrgDetail": "Das Emittentenkonto ist die wichtigste On-Chain-Referenz für dieses Asset."
   },
   "assetsMeta": {
     "stellarLumens": "Stellar Lumens",
@@ -842,7 +861,10 @@
     "noTransactionsDesc": "Dieser Ledger enthält keine Transaktionen.",
     "failedToLoadTx": "Fehler beim Laden der Transaktionen",
     "prev": "Zurück",
-    "next": "Weiter"
+    "next": "Weiter",
+    "contextTitle": "Ledger-Zusammenfassung",
+    "contextSummary": "Ledger #{sequence} wurde um {closedAt} geschlossen und enthielt {successful} erfolgreiche sowie {failed} fehlgeschlagene Transaktionen; dabei wurden {operations} Operationen unter Protokoll {protocol} verarbeitet.",
+    "contextFeeDetail": "Der Gebührenpool lag beim Schließen bei {feePool} XLM, die Basisgebühr bei {baseFee} Stroops."
   },
   "noFeeData": "Keine Gebührendaten verfügbar",
   "noTransactionData": "Keine Transaktionsdaten",

--- a/messages/en.json
+++ b/messages/en.json
@@ -217,6 +217,11 @@
     "failedToLoadCode": "Failed to load contract code",
     "noCode": "No code found",
     "noCodeDescription": "Unable to retrieve the contract code.",
+    "contextTitle": "Contract context",
+    "contextWasmSummary": "This contract is deployed as custom Soroban WASM code and currently exposes {storage} instance storage entries.",
+    "contextSacSummary": "This contract is a Stellar Asset Contract wrapper, so it follows the standard asset interface instead of custom WASM bytecode.",
+    "contextStorageDetail": "Current storage TTL is about {ttl} ledgers.",
+    "contextNoStorageDetail": "No instance storage entries are currently visible.",
     "stellarAssetContract": "Stellar Asset Contract",
     "sacDescription": "This is a native Stellar Asset Contract (SAC). It wraps a Stellar asset and doesn't have custom WASM code.",
     "nativeContract": "Native Contract",
@@ -286,7 +291,12 @@
     "failedToLoadOps": "Failed to load operations",
     "failedToLoadEffects": "Failed to load effects",
     "envelopeXdr": "Envelope XDR",
-    "resultXdr": "Result XDR"
+    "resultXdr": "Result XDR",
+    "contextTitle": "What happened",
+    "contextSuccessSummary": "This transaction reached ledger #{ledger} with {operations} operations and paid {fee} XLM from {source}.",
+    "contextFailedSummary": "This transaction failed in ledger #{ledger} after attempting {operations} operations with a fee charge of {fee} XLM from {source}.",
+    "contextMemoDetail": "A memo was attached: {memo}.",
+    "contextNoMemoDetail": "No memo was attached to this transaction."
   },
   "account": {
     "title": "Account",
@@ -315,7 +325,11 @@
     "limit": "Limit:",
     "max": "Max",
     "sorobanCall": "Soroban Contract Call",
-    "weight": "Weight: {weight}"
+    "weight": "Weight: {weight}",
+    "contextTitle": "Account context",
+    "contextSummary": "This account currently holds {xlm} XLM, tracks {assets} non-native assets, and uses {signers} signer(s) across {subentries} subentries.",
+    "contextHomeDomainDetail": "Its declared home domain is {domain}.",
+    "contextNoHomeDomainDetail": "No home domain is declared for this account."
   },
   "operations": {
     "create_account": "Create Account",
@@ -641,7 +655,12 @@
     "xlmPurpose1": "Pay transaction fees (typically 0.00001 XLM per operation)",
     "xlmPurpose2": "Maintain minimum account balances (base reserve)",
     "xlmPurpose3": "Prevent spam by requiring small amounts for account creation",
-    "xlmPurpose4": "Bridge currency for cross-asset transactions via the DEX"
+    "xlmPurpose4": "Bridge currency for cross-asset transactions via the DEX",
+    "contextTitle": "Asset context",
+    "contextOpenSummary": "{asset} is issued by {issuer} with {holders} holding accounts and an estimated supply of {supply}. Access is currently open for trustlines and transfers.",
+    "contextRestrictedSummary": "{asset} is issued by {issuer} with {holders} holding accounts and an estimated supply of {supply}. Issuer controls such as authorization or revocation are enabled.",
+    "contextOrgDetail": "{org} publishes the related Stellar metadata for this asset.",
+    "contextNoOrgDetail": "The issuer account is the primary on-chain reference for this asset."
   },
   "ledgerDetails": {
     "title": "Ledger",
@@ -663,7 +682,10 @@
     "noTransactionsDesc": "This ledger doesn't contain any transactions.",
     "failedToLoadTx": "Failed to load transactions",
     "prev": "Prev",
-    "next": "Next"
+    "next": "Next",
+    "contextTitle": "Ledger summary",
+    "contextSummary": "Ledger #{sequence} closed at {closedAt} with {successful} successful and {failed} failed transactions, processing {operations} operations on protocol {protocol}.",
+    "contextFeeDetail": "The fee pool stood at {feePool} XLM with a base fee of {baseFee} stroops at close."
   },
   "searchPage": {
     "noQuery": "No search query",

--- a/messages/es.json
+++ b/messages/es.json
@@ -217,6 +217,11 @@
     "failedToLoadCode": "Error al cargar el código del contrato",
     "noCode": "No se encontró código",
     "noCodeDescription": "No se pudo obtener el código del contrato.",
+    "contextTitle": "Contexto del contrato",
+    "contextWasmSummary": "Este contrato está desplegado como código WASM personalizado de Soroban y actualmente expone {storage} entradas de almacenamiento de instancia.",
+    "contextSacSummary": "Este contrato es un envoltorio de Stellar Asset Contract, por lo que sigue la interfaz estándar del activo en lugar de bytecode WASM personalizado.",
+    "contextStorageDetail": "El TTL actual del almacenamiento es de aproximadamente {ttl} ledgers.",
+    "contextNoStorageDetail": "Actualmente no hay entradas visibles de almacenamiento de instancia.",
     "stellarAssetContract": "Contrato de Activo Stellar",
     "sacDescription": "Este es un Contrato de Activo Stellar (SAC) nativo. Envuelve un activo Stellar y no tiene código WASM personalizado.",
     "nativeContract": "Contrato Nativo",
@@ -286,7 +291,12 @@
     "failedToLoadOps": "Error al cargar operaciones",
     "failedToLoadEffects": "Error al cargar efectos",
     "envelopeXdr": "Envelope XDR",
-    "resultXdr": "Result XDR"
+    "resultXdr": "Result XDR",
+    "contextTitle": "Qué ocurrió",
+    "contextSuccessSummary": "Esta transacción llegó al ledger #{ledger} con {operations} operaciones y pagó {fee} XLM desde {source}.",
+    "contextFailedSummary": "Esta transacción falló en el ledger #{ledger} tras intentar {operations} operaciones con un cargo de {fee} XLM desde {source}.",
+    "contextMemoDetail": "Se adjuntó un memo: {memo}.",
+    "contextNoMemoDetail": "No se adjuntó ningún memo a esta transacción."
   },
   "account": {
     "title": "Cuenta",
@@ -315,7 +325,11 @@
     "limit": "Límite:",
     "max": "Máx",
     "sorobanCall": "Llamada a contrato Soroban",
-    "weight": "Peso: {weight}"
+    "weight": "Peso: {weight}",
+    "contextTitle": "Contexto de la cuenta",
+    "contextSummary": "Esta cuenta actualmente mantiene {xlm} XLM, sigue {assets} activos no nativos y usa {signers} firmante(s) en {subentries} subentradas.",
+    "contextHomeDomainDetail": "Su home domain declarado es {domain}.",
+    "contextNoHomeDomainDetail": "Esta cuenta no declara un home domain."
   },
   "operations": {
     "create_account": "Crear cuenta",
@@ -641,7 +655,12 @@
     "xlmPurpose1": "Pagar tarifas de transacción (típicamente 0.00001 XLM por operación)",
     "xlmPurpose2": "Mantener balances mínimos de cuenta (reserva base)",
     "xlmPurpose3": "Prevenir spam requiriendo pequeñas cantidades para crear cuentas",
-    "xlmPurpose4": "Moneda puente para transacciones entre activos vía el DEX"
+    "xlmPurpose4": "Moneda puente para transacciones entre activos vía el DEX",
+    "contextTitle": "Contexto del activo",
+    "contextOpenSummary": "{asset} es emitido por {issuer}, tiene {holders} cuentas tenedoras y un suministro estimado de {supply}. El acceso está abierto para trustlines y transferencias.",
+    "contextRestrictedSummary": "{asset} es emitido por {issuer}, tiene {holders} cuentas tenedoras y un suministro estimado de {supply}. Están habilitados controles del emisor como autorización o revocación.",
+    "contextOrgDetail": "{org} publica la metadata de Stellar asociada a este activo.",
+    "contextNoOrgDetail": "La cuenta emisora es la referencia principal on-chain para este activo."
   },
   "ledgerDetails": {
     "title": "Libro",
@@ -663,7 +682,10 @@
     "noTransactionsDesc": "Este libro no contiene ninguna transacción.",
     "failedToLoadTx": "Error al cargar transacciones",
     "prev": "Ant",
-    "next": "Sig"
+    "next": "Sig",
+    "contextTitle": "Resumen del ledger",
+    "contextSummary": "El ledger #{sequence} se cerró en {closedAt} con {successful} transacciones exitosas y {failed} fallidas, procesando {operations} operaciones en el protocolo {protocol}.",
+    "contextFeeDetail": "El fee pool cerró en {feePool} XLM con una tarifa base de {baseFee} stroops."
   },
   "searchPage": {
     "noQuery": "Sin consulta de búsqueda",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -256,7 +256,12 @@
     "noTransactions": "Aucune transaction disponible",
     "noTransactionsDesc": "Désolé, notre infrastructure actuelle ne conserve qu'environ 7 jours de données de transactions. Nous construisons activement un indexeur qui permettra un historique complet des transactions, des données d'événements détaillées et une couverture totale de la blockchain.",
     "lastActivity": "Dernière Activité",
-    "contractTransactions": "Transactions"
+    "contractTransactions": "Transactions",
+    "contextTitle": "Contexte du contrat",
+    "contextWasmSummary": "Ce contrat est déployé sous forme de code WASM Soroban personnalisé et expose actuellement {storage} entrées de stockage d’instance.",
+    "contextSacSummary": "Ce contrat est un wrapper Stellar Asset Contract ; il suit donc l’interface standard de l’actif au lieu d’un bytecode WASM personnalisé.",
+    "contextStorageDetail": "Le TTL actuel du stockage est d’environ {ttl} registres.",
+    "contextNoStorageDetail": "Aucune entrée de stockage d’instance n’est visible pour le moment."
   },
   "watchlist": {
     "title": "Favoris",
@@ -286,7 +291,12 @@
     "failedToLoadOps": "Échec du chargement des opérations",
     "failedToLoadEffects": "Échec du chargement des effets",
     "envelopeXdr": "Envelope XDR",
-    "resultXdr": "Result XDR"
+    "resultXdr": "Result XDR",
+    "contextTitle": "Ce qui s'est passé",
+    "contextSuccessSummary": "Cette transaction a été incluse dans le registre #{ledger} avec {operations} opérations et a payé {fee} XLM depuis {source}.",
+    "contextFailedSummary": "Cette transaction a échoué dans le registre #{ledger} après avoir tenté {operations} opérations, avec des frais facturés de {fee} XLM depuis {source}.",
+    "contextMemoDetail": "Un mémo a été joint : {memo}.",
+    "contextNoMemoDetail": "Aucun mémo n’a été joint à cette transaction."
   },
   "account": {
     "title": "Compte",
@@ -315,7 +325,11 @@
     "limit": "Limite:",
     "max": "Max",
     "sorobanCall": "Appel de Contrat Soroban",
-    "weight": "Poids: {weight}"
+    "weight": "Poids: {weight}",
+    "contextTitle": "Contexte du compte",
+    "contextSummary": "Ce compte détient actuellement {xlm} XLM, suit {assets} actifs non natifs et utilise {signers} signataire(s) sur {subentries} sous-entrées.",
+    "contextHomeDomainDetail": "Son home domain déclaré est {domain}.",
+    "contextNoHomeDomainDetail": "Aucun home domain n’est déclaré pour ce compte."
   },
   "operations": {
     "create_account": "Creer un compte",
@@ -571,7 +585,12 @@
     "xlmPurpose1": "Payer les frais de transaction (généralement 0.00001 XLM par opération)",
     "xlmPurpose2": "Maintenir les soldes minimum du compte (réserve de base)",
     "xlmPurpose3": "Prévenir le spam en exigeant de petits montants pour la création de compte",
-    "xlmPurpose4": "Monnaie pont pour les transactions inter-actifs via le DEX"
+    "xlmPurpose4": "Monnaie pont pour les transactions inter-actifs via le DEX",
+    "contextTitle": "Contexte de l’actif",
+    "contextOpenSummary": "{asset} est émis par {issuer}, avec {holders} comptes détenteurs et une offre estimée à {supply}. L’accès est actuellement ouvert pour les trustlines et les transferts.",
+    "contextRestrictedSummary": "{asset} est émis par {issuer}, avec {holders} comptes détenteurs et une offre estimée à {supply}. Les contrôles de l’émetteur, comme l’autorisation ou la révocation, sont activés.",
+    "contextOrgDetail": "{org} publie les métadonnées Stellar associées à cet actif.",
+    "contextNoOrgDetail": "Le compte émetteur est la principale référence on-chain pour cet actif."
   },
   "assetsMeta": {
     "stellarLumens": "Stellar Lumens",
@@ -842,7 +861,10 @@
     "noTransactionsDesc": "Ce registre ne contient aucune transaction.",
     "failedToLoadTx": "Échec du chargement des transactions",
     "prev": "Précédent",
-    "next": "Suivant"
+    "next": "Suivant",
+    "contextTitle": "Résumé du registre",
+    "contextSummary": "Le registre #{sequence} s’est fermé à {closedAt}, avec {successful} transactions réussies et {failed} échouées, traitant {operations} opérations sur le protocole {protocol}.",
+    "contextFeeDetail": "Le fee pool s’élevait à {feePool} XLM avec des frais de base de {baseFee} stroops à la clôture."
   },
   "noFeeData": "Données de frais indisponibles",
   "noTransactionData": "Aucune donnée de transaction",

--- a/messages/it.json
+++ b/messages/it.json
@@ -256,7 +256,12 @@
     "noTransactions": "Nessuna transazione disponibile",
     "noTransactionsDesc": "Spiacenti, la nostra infrastruttura attuale conserva circa 7 giorni di dati di transazione. Stiamo costruendo attivamente un indicizzatore che consentirà la cronologia completa delle transazioni, dati di eventi dettagliati e copertura completa della blockchain.",
     "lastActivity": "Ultima attività",
-    "contractTransactions": "Transazioni"
+    "contractTransactions": "Transazioni",
+    "contextTitle": "Contesto del contratto",
+    "contextWasmSummary": "Questo contratto è distribuito come codice WASM Soroban personalizzato ed espone attualmente {storage} voci di storage di istanza.",
+    "contextSacSummary": "Questo contratto è un wrapper Stellar Asset Contract e quindi segue l’interfaccia standard dell’asset invece di un bytecode WASM personalizzato.",
+    "contextStorageDetail": "L’attuale TTL dello storage è di circa {ttl} ledger.",
+    "contextNoStorageDetail": "Al momento non sono visibili voci di storage di istanza."
   },
   "watchlist": {
     "title": "Lista di controllo",
@@ -286,7 +291,12 @@
     "failedToLoadOps": "Impossibile caricare le operazioni",
     "failedToLoadEffects": "Impossibile caricare gli effetti",
     "envelopeXdr": "Envelope XDR",
-    "resultXdr": "Result XDR"
+    "resultXdr": "Result XDR",
+    "contextTitle": "Cosa è successo",
+    "contextSuccessSummary": "Questa transazione è entrata nel ledger #{ledger} con {operations} operazioni e ha pagato {fee} XLM da {source}.",
+    "contextFailedSummary": "Questa transazione è fallita nel ledger #{ledger} dopo aver tentato {operations} operazioni, con una fee addebitata di {fee} XLM da {source}.",
+    "contextMemoDetail": "È stato allegato un memo: {memo}.",
+    "contextNoMemoDetail": "Nessun memo è stato allegato a questa transazione."
   },
   "account": {
     "title": "Conto",
@@ -315,7 +325,11 @@
     "limit": "Limite:",
     "max": "Max",
     "sorobanCall": "Chiamata contratto Soroban",
-    "weight": "Peso: {weight}"
+    "weight": "Peso: {weight}",
+    "contextTitle": "Contesto dell’account",
+    "contextSummary": "Questo account detiene attualmente {xlm} XLM, monitora {assets} asset non nativi e usa {signers} firmatario/i su {subentries} sotto-voci.",
+    "contextHomeDomainDetail": "Il suo home domain dichiarato è {domain}.",
+    "contextNoHomeDomainDetail": "Per questo account non è dichiarato alcun home domain."
   },
   "operations": {
     "create_account": "Crea conto",
@@ -641,7 +655,12 @@
     "xlmPurpose1": "Pagare le commissioni di transazione (tipicamente 0,00001 XLM per operazione)",
     "xlmPurpose2": "Mantenere i saldi minimi del conto (riserva base)",
     "xlmPurpose3": "Prevenire lo spam richiedendo piccole quantità per la creazione dell'account",
-    "xlmPurpose4": "Valuta ponte per transazioni tra diverse risorse tramite il DEX"
+    "xlmPurpose4": "Valuta ponte per transazioni tra diverse risorse tramite il DEX",
+    "contextTitle": "Contesto dell’asset",
+    "contextOpenSummary": "{asset} è emesso da {issuer}, con {holders} account detentori e una supply stimata di {supply}. L’accesso è attualmente aperto per trustline e trasferimenti.",
+    "contextRestrictedSummary": "{asset} è emesso da {issuer}, con {holders} account detentori e una supply stimata di {supply}. Sono abilitati controlli dell’emittente come autorizzazione o revoca.",
+    "contextOrgDetail": "{org} pubblica i metadati Stellar relativi a questo asset.",
+    "contextNoOrgDetail": "L’account emittente è il principale riferimento on-chain per questo asset."
   },
   "ledgerDetails": {
     "title": "Registro",
@@ -663,7 +682,10 @@
     "noTransactionsDesc": "Questo registro non contiene transazioni.",
     "failedToLoadTx": "Impossibile caricare le transazioni",
     "prev": "Prec",
-    "next": "Succ"
+    "next": "Succ",
+    "contextTitle": "Riepilogo del ledger",
+    "contextSummary": "Il ledger #{sequence} si è chiuso alle {closedAt}, con {successful} transazioni riuscite e {failed} non riuscite, elaborando {operations} operazioni sul protocollo {protocol}.",
+    "contextFeeDetail": "Alla chiusura il fee pool era pari a {feePool} XLM con una fee base di {baseFee} stroops."
   },
   "searchPage": {
     "noQuery": "Nessuna query di ricerca",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -256,7 +256,12 @@
     "noTransactions": "トランザクションデータなし",
     "noTransactionsDesc": "申し訳ありません。現在のインフラストラクチャでは約7日間のトランザクションデータのみ保持しています。完全なトランザクション履歴、詳細なイベントデータ、ブロックチェーン全体のカバレッジを提供するインデクサーを積極的に構築中です。",
     "lastActivity": "最終アクティビティ",
-    "contractTransactions": "トランザクション"
+    "contractTransactions": "トランザクション",
+    "contextTitle": "コントラクトの概要",
+    "contextWasmSummary": "このコントラクトはカスタム Soroban WASM コードとしてデプロイされており、現在 {storage} 件のインスタンスストレージ項目を公開しています。",
+    "contextSacSummary": "このコントラクトは Stellar Asset Contract のラッパーであり、カスタム WASM バイトコードではなく標準の資産インターフェースに従います。",
+    "contextStorageDetail": "現在のストレージ TTL は約 {ttl} レジャーです。",
+    "contextNoStorageDetail": "現在表示できるインスタンスストレージ項目はありません。"
   },
   "watchlist": {
     "title": "ウォッチリスト",
@@ -286,7 +291,12 @@
     "failedToLoadOps": "オペレーションの読み込みに失敗",
     "failedToLoadEffects": "エフェクトの読み込みに失敗",
     "envelopeXdr": "エンベロープXDR",
-    "resultXdr": "結果XDR"
+    "resultXdr": "結果XDR",
+    "contextTitle": "何が起きたか",
+    "contextSuccessSummary": "このトランザクションはレジャー #{ledger} に取り込まれ、{operations} 件のオペレーションを含み、{source} から {fee} XLM の手数料を支払いました。",
+    "contextFailedSummary": "このトランザクションはレジャー #{ledger} で失敗し、{operations} 件のオペレーションを試行した結果、{source} から {fee} XLM の手数料が請求されました。",
+    "contextMemoDetail": "メモが添付されています: {memo}。",
+    "contextNoMemoDetail": "このトランザクションにはメモが添付されていません。"
   },
   "account": {
     "title": "アカウント",
@@ -315,7 +325,11 @@
     "limit": "限度：",
     "max": "最大",
     "sorobanCall": "Sorobanコントラクト呼び出し",
-    "weight": "ウェイト：{weight}"
+    "weight": "ウェイト：{weight}",
+    "contextTitle": "アカウントの概要",
+    "contextSummary": "このアカウントは現在 {xlm} XLM を保有し、{assets} 件のネイティブ以外の資産を追跡し、{subentries} 件のサブエントリーに対して {signers} 人の署名者を使用しています。",
+    "contextHomeDomainDetail": "宣言されている home domain は {domain} です。",
+    "contextNoHomeDomainDetail": "このアカウントには home domain が設定されていません。"
   },
   "operations": {
     "create_account": "アカウント作成",
@@ -571,7 +585,12 @@
     "xlmPurpose1": "トランザクション手数料の支払い（通常、操作ごとに0.00001 XLM）",
     "xlmPurpose2": "最低アカウント残高の維持（基本リザーブ）",
     "xlmPurpose3": "アカウント作成に少額を要求することでスパムを防止",
-    "xlmPurpose4": "DEXを介したクロスアセット取引のブリッジ通貨"
+    "xlmPurpose4": "DEXを介したクロスアセット取引のブリッジ通貨",
+    "contextTitle": "アセットの概要",
+    "contextOpenSummary": "{asset} は {issuer} によって発行され、{holders} 件の保有アカウントと推定供給量 {supply} を持ちます。現在、trustline と送金へのアクセスは開放されています。",
+    "contextRestrictedSummary": "{asset} は {issuer} によって発行され、{holders} 件の保有アカウントと推定供給量 {supply} を持ちます。承認や取消しなどの発行者コントロールが有効です。",
+    "contextOrgDetail": "{org} はこのアセットに関連する Stellar メタデータを公開しています。",
+    "contextNoOrgDetail": "発行アカウントはこのアセットの主要なオンチェーン参照です。"
   },
   "assetsMeta": {
     "stellarLumens": "Stellar Lumens",
@@ -842,7 +861,10 @@
     "noTransactionsDesc": "このレジャーにはトランザクションがありません。",
     "failedToLoadTx": "トランザクションの読み込みに失敗しました",
     "prev": "前へ",
-    "next": "次へ"
+    "next": "次へ",
+    "contextTitle": "レジャー概要",
+    "contextSummary": "レジャー #{sequence} は {closedAt} にクローズし、{successful} 件の成功トランザクションと {failed} 件の失敗トランザクションを含み、プロトコル {protocol} 上で {operations} 件のオペレーションを処理しました。",
+    "contextFeeDetail": "クローズ時の fee pool は {feePool} XLM、基本手数料は {baseFee} stroops でした。"
   },
   "noFeeData": "手数料データがありません",
   "noTransactionData": "トランザクションデータがありません",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -256,7 +256,12 @@
     "noTransactions": "트랜잭션 데이터 없음",
     "noTransactionsDesc": "죄송합니다. 현재 인프라는 약 7일간의 트랜잭션 데이터만 보존합니다. 완전한 트랜잭션 기록, 상세한 이벤트 데이터, 전체 블록체인 커버리지를 제공할 인덱서를 적극적으로 구축하고 있습니다.",
     "lastActivity": "마지막 활동",
-    "contractTransactions": "트랜잭션"
+    "contractTransactions": "트랜잭션",
+    "contextTitle": "컨트랙트 맥락",
+    "contextWasmSummary": "이 컨트랙트는 사용자 정의 Soroban WASM 코드로 배포되었으며 현재 {storage}개의 인스턴스 저장소 항목을 노출합니다.",
+    "contextSacSummary": "이 컨트랙트는 Stellar Asset Contract 래퍼이므로 사용자 정의 WASM 바이트코드 대신 표준 자산 인터페이스를 따릅니다.",
+    "contextStorageDetail": "현재 저장소 TTL은 약 {ttl}개 ledger입니다.",
+    "contextNoStorageDetail": "현재 표시 가능한 인스턴스 저장소 항목이 없습니다."
   },
   "watchlist": {
     "title": "관심목록",
@@ -286,7 +291,12 @@
     "failedToLoadOps": "오퍼레이션을 불러오는데 실패했습니다",
     "failedToLoadEffects": "효과를 불러오는데 실패했습니다",
     "envelopeXdr": "엔벨로프 XDR",
-    "resultXdr": "결과 XDR"
+    "resultXdr": "결과 XDR",
+    "contextTitle": "무슨 일이 있었나",
+    "contextSuccessSummary": "이 트랜잭션은 ledger #{ledger}에 포함되었고 {operations}개의 작업을 수행했으며 {source}에서 {fee} XLM 수수료를 지불했습니다.",
+    "contextFailedSummary": "이 트랜잭션은 ledger #{ledger}에서 실패했으며 {operations}개의 작업을 시도한 뒤 {source}에서 {fee} XLM 수수료가 청구되었습니다.",
+    "contextMemoDetail": "메모가 첨부되었습니다: {memo}.",
+    "contextNoMemoDetail": "이 트랜잭션에는 메모가 첨부되지 않았습니다."
   },
   "account": {
     "title": "계정",
@@ -315,7 +325,11 @@
     "limit": "한도:",
     "max": "최대",
     "sorobanCall": "Soroban 컨트랙트 호출",
-    "weight": "가중치: {weight}"
+    "weight": "가중치: {weight}",
+    "contextTitle": "계정 맥락",
+    "contextSummary": "이 계정은 현재 {xlm} XLM을 보유하고, {assets}개의 네이티브 외 자산을 추적하며, {subentries}개의 하위 항목에 대해 {signers}명의 서명자를 사용합니다.",
+    "contextHomeDomainDetail": "선언된 home domain은 {domain}입니다.",
+    "contextNoHomeDomainDetail": "이 계정에는 home domain이 선언되어 있지 않습니다."
   },
   "operations": {
     "create_account": "계정 생성",
@@ -641,7 +655,12 @@
     "xlmPurpose1": "트랜잭션 수수료 지불 (일반적으로 오퍼레이션당 0.00001 XLM)",
     "xlmPurpose2": "최소 계정 잔액 유지 (기본 준비금)",
     "xlmPurpose3": "계정 생성에 소량 요구하여 스팸 방지",
-    "xlmPurpose4": "DEX를 통한 교차 자산 거래의 브릿지 통화"
+    "xlmPurpose4": "DEX를 통한 교차 자산 거래의 브릿지 통화",
+    "contextTitle": "자산 맥락",
+    "contextOpenSummary": "{asset}은(는) {issuer}가 발행했으며, {holders}개의 보유 계정과 추정 공급량 {supply}를 가집니다. 현재 trustline과 전송에 대한 접근은 열려 있습니다.",
+    "contextRestrictedSummary": "{asset}은(는) {issuer}가 발행했으며, {holders}개의 보유 계정과 추정 공급량 {supply}를 가집니다. 승인 또는 회수와 같은 발행자 제어가 활성화되어 있습니다.",
+    "contextOrgDetail": "{org}가 이 자산과 관련된 Stellar 메타데이터를 게시합니다.",
+    "contextNoOrgDetail": "발행 계정은 이 자산의 주요 온체인 기준점입니다."
   },
   "ledgerDetails": {
     "title": "원장",
@@ -663,7 +682,10 @@
     "noTransactionsDesc": "이 원장에는 트랜잭션이 포함되어 있지 않습니다.",
     "failedToLoadTx": "트랜잭션을 불러오는데 실패했습니다",
     "prev": "이전",
-    "next": "다음"
+    "next": "다음",
+    "contextTitle": "원장 요약",
+    "contextSummary": "ledger #{sequence}는 {closedAt}에 마감되었고, {successful}개의 성공 거래와 {failed}개의 실패 거래를 포함했으며, 프로토콜 {protocol}에서 {operations}개의 작업을 처리했습니다.",
+    "contextFeeDetail": "마감 시 fee pool은 {feePool} XLM이었고 기본 수수료는 {baseFee} stroops였습니다."
   },
   "searchPage": {
     "noQuery": "검색어 없음",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -256,7 +256,12 @@
     "noTransactions": "Nenhuma transação disponível",
     "noTransactionsDesc": "Desculpe, nossa infraestrutura atual retém apenas aproximadamente 7 dias de dados de transações. Estamos construindo ativamente um indexador que permitirá o histórico completo de transações, dados detalhados de eventos e cobertura total da blockchain.",
     "lastActivity": "Última Atividade",
-    "contractTransactions": "Transações"
+    "contractTransactions": "Transações",
+    "contextTitle": "Contexto do contrato",
+    "contextWasmSummary": "Este contrato está implantado como código WASM personalizado de Soroban e atualmente expõe {storage} entradas de armazenamento de instância.",
+    "contextSacSummary": "Este contrato é um wrapper de Stellar Asset Contract, portanto segue a interface padrão do ativo em vez de bytecode WASM personalizado.",
+    "contextStorageDetail": "O TTL atual do armazenamento é de cerca de {ttl} livros.",
+    "contextNoStorageDetail": "Nenhuma entrada de armazenamento de instância está visível no momento."
   },
   "watchlist": {
     "title": "Favoritos",
@@ -286,7 +291,12 @@
     "failedToLoadOps": "Falha ao carregar operações",
     "failedToLoadEffects": "Falha ao carregar efeitos",
     "envelopeXdr": "Envelope XDR",
-    "resultXdr": "Result XDR"
+    "resultXdr": "Result XDR",
+    "contextTitle": "O que aconteceu",
+    "contextSuccessSummary": "Esta transação entrou no livro #{ledger} com {operations} operações e pagou {fee} XLM a partir de {source}.",
+    "contextFailedSummary": "Esta transação falhou no livro #{ledger} após tentar {operations} operações, com uma taxa cobrada de {fee} XLM a partir de {source}.",
+    "contextMemoDetail": "Um memo foi anexado: {memo}.",
+    "contextNoMemoDetail": "Nenhum memo foi anexado a esta transação."
   },
   "account": {
     "title": "Conta",
@@ -315,7 +325,11 @@
     "limit": "Limite:",
     "max": "Máx",
     "sorobanCall": "Chamada de Contrato Soroban",
-    "weight": "Peso: {weight}"
+    "weight": "Peso: {weight}",
+    "contextTitle": "Contexto da conta",
+    "contextSummary": "Esta conta atualmente mantém {xlm} XLM, acompanha {assets} ativos não nativos e usa {signers} signatário(s) em {subentries} subentradas.",
+    "contextHomeDomainDetail": "Seu home domain declarado é {domain}.",
+    "contextNoHomeDomainDetail": "Nenhum home domain está declarado para esta conta."
   },
   "operations": {
     "create_account": "Criar conta",
@@ -571,7 +585,12 @@
     "xlmPurpose1": "Pagar taxas de transação (tipicamente 0.00001 XLM por operação)",
     "xlmPurpose2": "Manter saldos mínimos de conta (reserva base)",
     "xlmPurpose3": "Prevenir spam exigindo pequenas quantias para criação de conta",
-    "xlmPurpose4": "Moeda ponte para transações entre ativos via DEX"
+    "xlmPurpose4": "Moeda ponte para transações entre ativos via DEX",
+    "contextTitle": "Contexto do ativo",
+    "contextOpenSummary": "{asset} é emitido por {issuer}, com {holders} contas detentoras e uma oferta estimada de {supply}. O acesso está atualmente aberto para trustlines e transferências.",
+    "contextRestrictedSummary": "{asset} é emitido por {issuer}, com {holders} contas detentoras e uma oferta estimada de {supply}. Controles do emissor, como autorização ou revogação, estão habilitados.",
+    "contextOrgDetail": "{org} publica os metadados Stellar relacionados a este ativo.",
+    "contextNoOrgDetail": "A conta emissora é a principal referência on-chain para este ativo."
   },
   "assetsMeta": {
     "stellarLumens": "Stellar Lumens",
@@ -842,7 +861,10 @@
     "noTransactionsDesc": "Este livro não contém transações.",
     "failedToLoadTx": "Falha ao carregar transações",
     "prev": "Anterior",
-    "next": "Próximo"
+    "next": "Próximo",
+    "contextTitle": "Resumo do livro",
+    "contextSummary": "O livro #{sequence} foi fechado em {closedAt}, com {successful} transações bem-sucedidas e {failed} falhas, processando {operations} operações no protocolo {protocol}.",
+    "contextFeeDetail": "O fee pool fechou em {feePool} XLM, com taxa base de {baseFee} stroops."
   },
   "noFeeData": "Dados de taxa indisponíveis",
   "noTransactionData": "Sem dados de transação",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -256,7 +256,12 @@
     "noTransactions": "暂无交易数据",
     "noTransactionsDesc": "抱歉，我们当前的基础设施仅保留约7天的交易数据。我们正在积极构建索引器，届时将提供完整的交易历史、详细的事件数据和全面的区块链覆盖。",
     "lastActivity": "最后活动",
-    "contractTransactions": "交易"
+    "contractTransactions": "交易",
+    "contextTitle": "合约上下文",
+    "contextWasmSummary": "该合约以自定义 Soroban WASM 代码部署，目前暴露出 {storage} 条实例存储项。",
+    "contextSacSummary": "该合约是 Stellar Asset Contract 的封装，因此遵循标准资产接口，而不是自定义 WASM 字节码。",
+    "contextStorageDetail": "当前存储 TTL 约为 {ttl} 个账本。",
+    "contextNoStorageDetail": "当前没有可见的实例存储项。"
   },
   "watchlist": {
     "title": "关注列表",
@@ -286,7 +291,12 @@
     "failedToLoadOps": "操作加载失败",
     "failedToLoadEffects": "效果加载失败",
     "envelopeXdr": "信封 XDR",
-    "resultXdr": "结果 XDR"
+    "resultXdr": "结果 XDR",
+    "contextTitle": "发生了什么",
+    "contextSuccessSummary": "这笔交易已写入账本 #{ledger}，包含 {operations} 个操作，并从 {source} 支付了 {fee} XLM 费用。",
+    "contextFailedSummary": "这笔交易在账本 #{ledger} 中失败，在尝试 {operations} 个操作后，从 {source} 扣除了 {fee} XLM 费用。",
+    "contextMemoDetail": "附带了一个 memo：{memo}。",
+    "contextNoMemoDetail": "这笔交易没有附带 memo。"
   },
   "account": {
     "title": "账户",
@@ -315,7 +325,11 @@
     "limit": "限额：",
     "max": "最大",
     "sorobanCall": "Soroban 合约调用",
-    "weight": "权重：{weight}"
+    "weight": "权重：{weight}",
+    "contextTitle": "账户上下文",
+    "contextSummary": "该账户当前持有 {xlm} XLM，跟踪 {assets} 个非原生资产，并在 {subentries} 个子条目上使用 {signers} 个签名者。",
+    "contextHomeDomainDetail": "其声明的 home domain 为 {domain}。",
+    "contextNoHomeDomainDetail": "该账户未声明 home domain。"
   },
   "operations": {
     "create_account": "创建账户",
@@ -571,7 +585,12 @@
     "xlmPurpose1": "支付交易费用（通常每笔操作 0.00001 XLM）",
     "xlmPurpose2": "维持最低账户余额（基础储备）",
     "xlmPurpose3": "通过要求创建账户时支付少量金额来防止垃圾交易",
-    "xlmPurpose4": "通过 DEX 进行跨资产交易的桥接货币"
+    "xlmPurpose4": "通过 DEX 进行跨资产交易的桥接货币",
+    "contextTitle": "资产上下文",
+    "contextOpenSummary": "{asset} 由 {issuer} 发行，当前有 {holders} 个持有账户，估算供应量为 {supply}。目前信任线和转账访问是开放的。",
+    "contextRestrictedSummary": "{asset} 由 {issuer} 发行，当前有 {holders} 个持有账户，估算供应量为 {supply}。发行方控制如授权或撤销已启用。",
+    "contextOrgDetail": "{org} 发布了与该资产相关的 Stellar 元数据。",
+    "contextNoOrgDetail": "发行账户是该资产最主要的链上参考。"
   },
   "assetsMeta": {
     "stellarLumens": "Stellar Lumens",
@@ -842,7 +861,10 @@
     "noTransactionsDesc": "此账本不包含任何交易。",
     "failedToLoadTx": "加载交易失败",
     "prev": "上一个",
-    "next": "下一个"
+    "next": "下一个",
+    "contextTitle": "账本摘要",
+    "contextSummary": "账本 #{sequence} 于 {closedAt} 关闭，包含 {successful} 笔成功交易和 {failed} 笔失败交易，共处理 {operations} 个操作，协议版本为 {protocol}。",
+    "contextFeeDetail": "关闭时费用池为 {feePool} XLM，基础费用为 {baseFee} stroops。"
   },
   "noFeeData": "无费用数据",
   "noTransactionData": "无交易数据",

--- a/src/app/[locale]/[network]/(explorer)/account/[id]/account-content.tsx
+++ b/src/app/[locale]/[network]/(explorer)/account/[id]/account-content.tsx
@@ -14,6 +14,7 @@ import { OperationBadge } from "@/components/common/operation-badge";
 import { LoadingCard } from "@/components/common/loading-card";
 import { ErrorState } from "@/components/common/error-state";
 import { EmptyState } from "@/components/common/empty-state";
+import { EntityContextCard } from "@/components/common/entity-context-card";
 import { TransactionCard, TransactionCardSkeleton } from "@/components/cards/transaction-card";
 import {
   useAccount,
@@ -32,6 +33,35 @@ import { useTranslations } from "next-intl";
 
 interface AccountContentProps {
   id: string;
+}
+
+function AccountContext({ account }: { account: Horizon.ServerApi.AccountRecord }) {
+  const t = useTranslations("account");
+  const xlmBalance = account.balances.find((balance) => balance.asset_type === "native");
+  const otherAssets = account.balances.filter((balance) => balance.asset_type !== "native").length;
+
+  return (
+    <EntityContextCard
+      title={t("contextTitle")}
+      summary={t("contextSummary", {
+        xlm: formatNumber(xlmBalance?.balance ?? 0),
+        assets: otherAssets,
+        signers: account.signers.length,
+        subentries: account.subentry_count,
+      })}
+      detail={
+        account.home_domain
+          ? t("contextHomeDomainDetail", { domain: account.home_domain })
+          : t("contextNoHomeDomainDetail")
+      }
+      metrics={[
+        { label: t("xlmBalance"), value: `${formatNumber(xlmBalance?.balance ?? 0)} XLM` },
+        { label: t("otherAssets"), value: String(otherAssets) },
+        { label: t("signers"), value: String(account.signers.length) },
+        { label: t("subentries"), value: String(account.subentry_count) },
+      ]}
+    />
+  );
 }
 
 function AccountSummary({ account }: { account: Horizon.ServerApi.AccountRecord }) {
@@ -366,6 +396,8 @@ export function AccountContent({ id }: AccountContentProps) {
           </Button>
         }
       />
+
+      <AccountContext account={account} />
 
       <AccountSummary account={account} />
 

--- a/src/app/[locale]/[network]/(explorer)/account/[id]/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/account/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { Metadata } from "next";
 import { AccountContent } from "./account-content";
+import { buildAccountMetadataCopy } from "@/lib/entity-metadata";
 import { buildExplorerMetadata } from "@/lib/seo";
+import { getAccountSnapshot } from "@/lib/stellar/server";
 import type { NetworkKey } from "@/types";
 
 type Props = {
@@ -9,23 +11,30 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale, network, id } = await params;
-  const shortId = `${id.slice(0, 6)}...${id.slice(-6)}`;
+  let copy = buildAccountMetadataCopy(id);
+
+  try {
+    const account = await getAccountSnapshot(network as NetworkKey, id);
+    copy = buildAccountMetadataCopy(id, account);
+  } catch {
+    // Keep generic metadata when server-side fetching fails.
+  }
 
   return buildExplorerMetadata({
     locale,
     network: network as NetworkKey,
     pathname: `/account/${id}`,
-    title: `Account ${shortId}`,
-    description: `View Stellar account ${shortId}. Explore balances, transactions, operations, and signers.`,
+    title: copy.title,
+    description: copy.description,
     openGraph: {
-      title: `Stellar Account ${shortId}`,
-      description: `View account details on Stellar Explorer`,
+      title: copy.title,
+      description: copy.description,
       type: "website",
     },
     twitter: {
       card: "summary",
-      title: `Stellar Account ${shortId}`,
-      description: `View account details on Stellar Explorer`,
+      title: copy.title,
+      description: copy.description,
     },
   });
 }

--- a/src/app/[locale]/[network]/(explorer)/asset/[slug]/asset-content.tsx
+++ b/src/app/[locale]/[network]/(explorer)/asset/[slug]/asset-content.tsx
@@ -10,8 +10,9 @@ import { HashDisplay } from "@/components/common/hash-display";
 import { LoadingCard } from "@/components/common/loading-card";
 import { ErrorState } from "@/components/common/error-state";
 import { AssetLogo } from "@/components/common/asset-logo";
+import { EntityContextCard } from "@/components/common/entity-context-card";
 import { useAsset, useAssetMetadata } from "@/lib/hooks";
-import { formatNumber, formatCompactNumber, parseAssetSlug } from "@/lib/utils";
+import { formatNumber, formatCompactNumber, parseAssetSlug, truncateHash } from "@/lib/utils";
 import type { Horizon } from "@stellar/stellar-sdk";
 import {
   Coins,
@@ -35,6 +36,44 @@ type AssetRecordExtended = Horizon.ServerApi.AssetRecord & {
 
 interface AssetContentProps {
   slug: string;
+}
+
+function AssetContext({
+  asset,
+  metadata,
+}: {
+  asset: AssetRecordExtended;
+  metadata?: { orgName?: string | null } | null;
+}) {
+  const t = useTranslations("assetDetails");
+  const isOpenAccess = !asset.flags.auth_required && !asset.flags.auth_revocable;
+  const summaryKey = isOpenAccess ? "contextOpenSummary" : "contextRestrictedSummary";
+
+  return (
+    <EntityContextCard
+      title={t("contextTitle")}
+      summary={t(summaryKey, {
+        asset: asset.asset_code,
+        issuer: truncateHash(asset.asset_issuer, 4, 4),
+        holders: formatCompactNumber(asset.num_accounts),
+        supply: formatCompactNumber(asset.amount),
+      })}
+      detail={
+        metadata?.orgName
+          ? t("contextOrgDetail", { org: metadata.orgName })
+          : t("contextNoOrgDetail")
+      }
+      metrics={[
+        { label: t("totalSupply"), value: formatCompactNumber(asset.amount) },
+        { label: t("accounts"), value: formatCompactNumber(asset.num_accounts) },
+        {
+          label: t("liquidityPools"),
+          value: formatCompactNumber(asset.num_liquidity_pools || 0),
+        },
+        { label: t("flags"), value: isOpenAccess ? t("openAccess") : t("restricted") },
+      ]}
+    />
+  );
 }
 
 function FlagBadge({
@@ -350,6 +389,8 @@ export function AssetContent({ slug }: AssetContentProps) {
           )}
         </div>
       </div>
+
+      <AssetContext asset={asset as AssetRecordExtended} metadata={metadata} />
 
       <AssetSummary asset={asset as AssetRecordExtended} />
 

--- a/src/app/[locale]/[network]/(explorer)/asset/[slug]/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/asset/[slug]/page.tsx
@@ -1,7 +1,9 @@
 import { Metadata } from "next";
 import { AssetContent } from "./asset-content";
+import { buildAssetMetadataCopy } from "@/lib/entity-metadata";
 import { parseAssetSlug } from "@/lib/utils";
 import { buildExplorerMetadata } from "@/lib/seo";
+import { getAssetSnapshot } from "@/lib/stellar/server";
 import type { NetworkKey } from "@/types";
 
 type Props = {
@@ -19,30 +21,32 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
 
   const { code, issuer } = parsed;
-  const isNative = issuer === "native";
-  const shortIssuer = isNative ? "Native" : `${issuer.slice(0, 4)}...${issuer.slice(-4)}`;
+  let copy = buildAssetMetadataCopy(code, issuer);
+
+  if (issuer !== "native") {
+    try {
+      const asset = await getAssetSnapshot(network as NetworkKey, code, issuer);
+      copy = buildAssetMetadataCopy(code, issuer, asset);
+    } catch {
+      // Keep generic metadata when server-side fetching fails.
+    }
+  }
 
   return buildExplorerMetadata({
     locale,
     network: network as NetworkKey,
     pathname: `/asset/${slug}`,
-    title: isNative ? "XLM - Stellar Lumens" : `${code} Asset`,
-    description: isNative
-      ? "XLM (Stellar Lumens) is the native asset of the Stellar network."
-      : `View details of ${code} asset on Stellar. Issuer: ${shortIssuer}. Explore supply, holders, and flags.`,
+    title: copy.title,
+    description: copy.description,
     openGraph: {
-      title: isNative ? "Stellar Lumens (XLM)" : `${code} - Stellar Asset`,
-      description: isNative
-        ? "Native asset of the Stellar network"
-        : `View ${code} asset details on Stellar Explorer`,
+      title: copy.title,
+      description: copy.description,
       type: "website",
     },
     twitter: {
       card: "summary",
-      title: isNative ? "Stellar Lumens (XLM)" : `${code} - Stellar Asset`,
-      description: isNative
-        ? "Native asset of the Stellar network"
-        : `View ${code} asset details on Stellar Explorer`,
+      title: copy.title,
+      description: copy.description,
     },
   });
 }

--- a/src/app/[locale]/[network]/(explorer)/contract/[id]/contract-content.tsx
+++ b/src/app/[locale]/[network]/(explorer)/contract/[id]/contract-content.tsx
@@ -13,6 +13,7 @@ import { HashDisplay } from "@/components/common/hash-display";
 import { LoadingCard } from "@/components/common/loading-card";
 import { ErrorState } from "@/components/common/error-state";
 import { EmptyState } from "@/components/common/empty-state";
+import { EntityContextCard } from "@/components/common/entity-context-card";
 import { useContractCode, useContractStorage } from "@/lib/hooks";
 import {
   ContractVerification,
@@ -39,6 +40,45 @@ import {
 
 interface ContractContentProps {
   id: string;
+}
+
+function ContractContext({ contractId }: { contractId: string }) {
+  const t = useTranslations("contract");
+  const { data: code } = useContractCode(contractId);
+  const { data: storage } = useContractStorage(contractId);
+
+  const summary =
+    code?.type === "sac"
+      ? t("contextSacSummary")
+      : t("contextWasmSummary", { storage: storage?.totalEntries ?? 0 });
+
+  const detail =
+    storage?.ttlLedgers !== null && storage?.ttlLedgers !== undefined
+      ? t("contextStorageDetail", { ttl: formatCompactNumber(storage.ttlLedgers) })
+      : t("contextNoStorageDetail");
+
+  return (
+    <EntityContextCard
+      title={t("contextTitle")}
+      summary={summary}
+      detail={detail}
+      metrics={[
+        {
+          label: t("type"),
+          value: code?.type === "sac" ? t("stellarAssetContract") : t("sorobanContract"),
+        },
+        { label: t("status"), value: t("active") },
+        { label: t("instanceStorage"), value: String(storage?.totalEntries ?? 0) },
+        {
+          label: t("ttl"),
+          value:
+            storage?.ttlLedgers !== null && storage?.ttlLedgers !== undefined
+              ? formatCompactNumber(storage.ttlLedgers)
+              : "-",
+        },
+      ]}
+    />
+  );
 }
 
 function ContractSummary({ contractId }: { contractId: string }) {
@@ -492,6 +532,8 @@ export function ContractContent({ id }: ContractContentProps) {
         backLabel={tCommon("home")}
         showQr={false}
       />
+
+      <ContractContext contractId={id} />
 
       <ContractSummary contractId={id} />
 

--- a/src/app/[locale]/[network]/(explorer)/contract/[id]/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/contract/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { Metadata } from "next";
 import { ContractContent } from "./contract-content";
+import { buildContractMetadataCopy } from "@/lib/entity-metadata";
 import { buildExplorerMetadata } from "@/lib/seo";
+import { getContractCodeSnapshot } from "@/lib/stellar/server";
 import type { NetworkKey } from "@/types";
 
 type Props = {
@@ -9,23 +11,30 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale, network, id } = await params;
-  const shortId = `${id.slice(0, 6)}...${id.slice(-6)}`;
+  let copy = buildContractMetadataCopy(id);
+
+  try {
+    const contractCode = await getContractCodeSnapshot(network as NetworkKey, id);
+    copy = buildContractMetadataCopy(id, contractCode);
+  } catch {
+    // Keep generic metadata when server-side fetching fails.
+  }
 
   return buildExplorerMetadata({
     locale,
     network: network as NetworkKey,
     pathname: `/contract/${id}`,
-    title: `Contract ${shortId}`,
-    description: `View Soroban smart contract ${shortId}. Explore events, storage, and contract code on Stellar.`,
+    title: copy.title,
+    description: copy.description,
     openGraph: {
-      title: `Soroban Contract ${shortId}`,
-      description: `View smart contract details on Stellar Explorer`,
+      title: copy.title,
+      description: copy.description,
       type: "website",
     },
     twitter: {
       card: "summary",
-      title: `Soroban Contract ${shortId}`,
-      description: `View smart contract details on Stellar Explorer`,
+      title: copy.title,
+      description: copy.description,
     },
   });
 }

--- a/src/app/[locale]/[network]/(explorer)/ledger/[sequence]/ledger-content.tsx
+++ b/src/app/[locale]/[network]/(explorer)/ledger/[sequence]/ledger-content.tsx
@@ -10,6 +10,7 @@ import { HashDisplay } from "@/components/common/hash-display";
 import { LoadingCard } from "@/components/common/loading-card";
 import { ErrorState } from "@/components/common/error-state";
 import { EmptyState } from "@/components/common/empty-state";
+import { EntityContextCard } from "@/components/common/entity-context-card";
 import { TransactionCard, TransactionCardSkeleton } from "@/components/cards/transaction-card";
 import { useLedger, useLedgerTransactions } from "@/lib/hooks";
 import { formatDateTime, formatLedgerSequence } from "@/lib/utils";
@@ -18,6 +19,41 @@ import { useTranslations } from "next-intl";
 
 interface LedgerContentProps {
   sequence: number;
+}
+
+function LedgerContext({
+  ledger,
+}: {
+  ledger: import("@stellar/stellar-sdk").Horizon.ServerApi.LedgerRecord;
+}) {
+  const t = useTranslations("ledgerDetails");
+
+  return (
+    <EntityContextCard
+      title={t("contextTitle")}
+      summary={t("contextSummary", {
+        sequence: formatLedgerSequence(ledger.sequence),
+        closedAt: formatDateTime(ledger.closed_at),
+        successful: ledger.successful_transaction_count,
+        failed: ledger.failed_transaction_count,
+        operations: ledger.operation_count,
+        protocol: ledger.protocol_version,
+      })}
+      detail={t("contextFeeDetail", {
+        feePool: ledger.fee_pool,
+        baseFee: ledger.base_fee_in_stroops,
+      })}
+      metrics={[
+        {
+          label: t("transactions"),
+          value: `${ledger.successful_transaction_count}/${ledger.failed_transaction_count}`,
+        },
+        { label: t("operations"), value: String(ledger.operation_count) },
+        { label: t("feePool"), value: `${ledger.fee_pool} XLM` },
+        { label: t("protocolVersion"), value: String(ledger.protocol_version) },
+      ]}
+    />
+  );
 }
 
 function LedgerNavigation({ sequence }: { sequence: number }) {
@@ -214,6 +250,8 @@ export function LedgerContent({ sequence }: LedgerContentProps) {
         showCopy={false}
         actions={<LedgerNavigation sequence={sequence} />}
       />
+
+      <LedgerContext ledger={ledger} />
 
       <LedgerSummary ledger={ledger} />
 

--- a/src/app/[locale]/[network]/(explorer)/ledger/[sequence]/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/ledger/[sequence]/page.tsx
@@ -1,7 +1,9 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { LedgerContent } from "./ledger-content";
+import { buildLedgerMetadataCopy } from "@/lib/entity-metadata";
 import { buildExplorerMetadata } from "@/lib/seo";
+import { getLedgerSnapshot } from "@/lib/stellar/server";
 import type { NetworkKey } from "@/types";
 
 type Props = {
@@ -18,23 +20,30 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     };
   }
 
-  const formattedSequence = sequenceNum.toLocaleString("en-US");
+  let copy = buildLedgerMetadataCopy(sequenceNum);
+
+  try {
+    const ledger = await getLedgerSnapshot(network as NetworkKey, sequenceNum);
+    copy = buildLedgerMetadataCopy(sequenceNum, ledger);
+  } catch {
+    // Keep generic metadata when server-side fetching fails.
+  }
 
   return buildExplorerMetadata({
     locale,
     network: network as NetworkKey,
     pathname: `/ledger/${sequenceNum}`,
-    title: `Ledger #${formattedSequence}`,
-    description: `View details of Stellar ledger #${formattedSequence}. Explore transactions, operations, and protocol information.`,
+    title: copy.title,
+    description: copy.description,
     openGraph: {
-      title: `Stellar Ledger #${formattedSequence}`,
-      description: `View ledger details on Stellar Explorer`,
+      title: copy.title,
+      description: copy.description,
       type: "website",
     },
     twitter: {
       card: "summary",
-      title: `Stellar Ledger #${formattedSequence}`,
-      description: `View ledger details on Stellar Explorer`,
+      title: copy.title,
+      description: copy.description,
     },
   });
 }

--- a/src/app/[locale]/[network]/(explorer)/tx/[hash]/page.tsx
+++ b/src/app/[locale]/[network]/(explorer)/tx/[hash]/page.tsx
@@ -1,7 +1,9 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { TransactionContent } from "./transaction-content";
+import { buildTransactionMetadataCopy } from "@/lib/entity-metadata";
 import { buildExplorerMetadata } from "@/lib/seo";
+import { getTransactionSnapshot } from "@/lib/stellar/server";
 import type { NetworkKey } from "@/types";
 
 type Props = {
@@ -14,23 +16,30 @@ function isValidTransactionHash(hash: string): boolean {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale, network, hash } = await params;
-  const shortHash = `${hash.slice(0, 8)}...${hash.slice(-8)}`;
+  let copy = buildTransactionMetadataCopy(hash);
+
+  try {
+    const transaction = await getTransactionSnapshot(network as NetworkKey, hash);
+    copy = buildTransactionMetadataCopy(hash, transaction);
+  } catch {
+    // Keep generic metadata when server-side fetching fails.
+  }
 
   return buildExplorerMetadata({
     locale,
     network: network as NetworkKey,
     pathname: `/tx/${hash}`,
-    title: `Transaction ${shortHash}`,
-    description: `View details of Stellar transaction ${shortHash}. Explore operations, effects, and raw XDR data.`,
+    title: copy.title,
+    description: copy.description,
     openGraph: {
-      title: `Stellar Transaction ${shortHash}`,
-      description: `View transaction details on Stellar Explorer`,
+      title: copy.title,
+      description: copy.description,
       type: "website",
     },
     twitter: {
       card: "summary",
-      title: `Stellar Transaction ${shortHash}`,
-      description: `View transaction details on Stellar Explorer`,
+      title: copy.title,
+      description: copy.description,
     },
   });
 }

--- a/src/app/[locale]/[network]/(explorer)/tx/[hash]/transaction-content.tsx
+++ b/src/app/[locale]/[network]/(explorer)/tx/[hash]/transaction-content.tsx
@@ -13,6 +13,7 @@ import { OperationBadge } from "@/components/common/operation-badge";
 import { LoadingCard } from "@/components/common/loading-card";
 import { ErrorState } from "@/components/common/error-state";
 import { DeveloperPanel } from "@/components/common/developer-panel";
+import { EntityContextCard } from "@/components/common/entity-context-card";
 import { useTransaction, useTransactionOperations, useTransactionEffects } from "@/lib/hooks";
 import { useNetwork } from "@/lib/providers";
 import { NETWORKS } from "@/lib/constants";
@@ -31,6 +32,42 @@ import { useTranslations } from "next-intl";
 
 interface TransactionContentProps {
   hash: string;
+}
+
+function TransactionContext({ transaction }: { transaction: Horizon.ServerApi.TransactionRecord }) {
+  const t = useTranslations("transaction");
+
+  const summary = transaction.successful
+    ? t("contextSuccessSummary", {
+        ledger: formatLedgerSequence(transaction.ledger_attr),
+        operations: transaction.operation_count,
+        fee: stroopsToXLM(transaction.fee_charged),
+        source: truncateHash(transaction.source_account, 6, 6),
+      })
+    : t("contextFailedSummary", {
+        ledger: formatLedgerSequence(transaction.ledger_attr),
+        operations: transaction.operation_count,
+        fee: stroopsToXLM(transaction.fee_charged),
+        source: truncateHash(transaction.source_account, 6, 6),
+      });
+
+  const detail = transaction.memo
+    ? t("contextMemoDetail", { memo: transaction.memo })
+    : t("contextNoMemoDetail");
+
+  return (
+    <EntityContextCard
+      title={t("contextTitle")}
+      summary={summary}
+      detail={detail}
+      metrics={[
+        { label: t("ledger"), value: `#${formatLedgerSequence(transaction.ledger_attr)}` },
+        { label: t("operationsCount"), value: String(transaction.operation_count) },
+        { label: t("feePaid"), value: `${stroopsToXLM(transaction.fee_charged)} XLM` },
+        { label: t("source"), value: truncateHash(transaction.source_account, 6, 6) },
+      ]}
+    />
+  );
 }
 
 function TransactionSummary({ transaction }: { transaction: Horizon.ServerApi.TransactionRecord }) {
@@ -365,6 +402,8 @@ export function TransactionContent({ hash }: TransactionContentProps) {
         showQr={false}
         badge={<StatusBadge status={transaction.successful ? "success" : "failed"} />}
       />
+
+      <TransactionContext transaction={transaction} />
 
       <TransactionSummary transaction={transaction} />
 

--- a/src/components/common/entity-context-card.tsx
+++ b/src/components/common/entity-context-card.tsx
@@ -1,0 +1,35 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface EntityContextMetric {
+  label: string;
+  value: string;
+}
+
+interface EntityContextCardProps {
+  title: string;
+  summary: string;
+  detail?: string;
+  metrics: EntityContextMetric[];
+}
+
+export function EntityContextCard({ title, summary, detail, metrics }: EntityContextCardProps) {
+  return (
+    <Card variant="gradient" className="border-0">
+      <CardHeader className="gap-3">
+        <CardTitle className="text-base">{title}</CardTitle>
+        <CardDescription className="max-w-3xl text-sm leading-6">{summary}</CardDescription>
+        {detail ? <p className="text-muted-foreground text-sm leading-6">{detail}</p> : null}
+      </CardHeader>
+      <CardContent className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {metrics.map((metric) => (
+          <div key={metric.label} className="bg-background/70 rounded-xl border px-4 py-3">
+            <div className="text-muted-foreground text-xs tracking-[0.12em] uppercase">
+              {metric.label}
+            </div>
+            <div className="mt-1 text-sm font-semibold">{metric.value}</div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/entity-metadata.ts
+++ b/src/lib/entity-metadata.ts
@@ -1,0 +1,134 @@
+import type { Horizon } from "@stellar/stellar-sdk";
+import {
+  formatCompactNumber,
+  formatLedgerSequence,
+  formatNumber,
+  stroopsToXLM,
+  truncateHash,
+} from "@/lib/utils";
+
+type AssetRecordExtended = Horizon.ServerApi.AssetRecord & {
+  amount?: string;
+  num_accounts?: number;
+};
+
+export function buildTransactionMetadataCopy(
+  hash: string,
+  transaction?: Horizon.ServerApi.TransactionRecord | null
+) {
+  const shortHash = truncateHash(hash, 8, 8);
+
+  if (!transaction) {
+    return {
+      title: `Transaction ${shortHash}`,
+      description: `View details of Stellar transaction ${shortHash}. Explore operations, effects, and raw XDR data.`,
+    };
+  }
+
+  const status = transaction.successful ? "Successful" : "Failed";
+  const ledger = formatLedgerSequence(transaction.ledger_attr);
+  const fee = stroopsToXLM(transaction.fee_charged);
+
+  return {
+    title: `${status} Transaction ${shortHash}`,
+    description: `${status} Stellar transaction ${shortHash} closed in ledger #${ledger} with ${transaction.operation_count} operations and ${fee} XLM in fees.`,
+  };
+}
+
+export function buildAccountMetadataCopy(
+  id: string,
+  account?: Horizon.ServerApi.AccountRecord | null
+) {
+  const shortId = truncateHash(id, 6, 6);
+
+  if (!account) {
+    return {
+      title: `Account ${shortId}`,
+      description: `View Stellar account ${shortId}. Explore balances, transactions, operations, and signers.`,
+    };
+  }
+
+  const xlmBalance = account.balances.find((balance) => balance.asset_type === "native");
+  const assetCount = account.balances.filter((balance) => balance.asset_type !== "native").length;
+
+  return {
+    title: `Account ${shortId} | ${formatNumber(xlmBalance?.balance ?? 0)} XLM`,
+    description: `Inspect Stellar account ${shortId} with ${formatNumber(xlmBalance?.balance ?? 0)} XLM, ${assetCount} non-native assets, and ${account.signers.length} signers.`,
+  };
+}
+
+export function buildLedgerMetadataCopy(
+  sequence: number,
+  ledger?: Horizon.ServerApi.LedgerRecord | null
+) {
+  const formattedSequence = formatLedgerSequence(sequence);
+
+  if (!ledger) {
+    return {
+      title: `Ledger #${formattedSequence}`,
+      description: `View details of Stellar ledger #${formattedSequence}. Explore transactions, operations, and protocol information.`,
+    };
+  }
+
+  const totalTransactions = ledger.successful_transaction_count + ledger.failed_transaction_count;
+
+  return {
+    title: `Ledger #${formattedSequence} | ${formatCompactNumber(totalTransactions)} txs`,
+    description: `Review Stellar ledger #${formattedSequence}, which closed with ${ledger.successful_transaction_count} successful transactions, ${ledger.failed_transaction_count} failed transactions, and ${ledger.operation_count} operations.`,
+  };
+}
+
+export function buildAssetMetadataCopy(
+  code: string,
+  issuer: string,
+  asset?: AssetRecordExtended | null
+) {
+  const isNative = issuer === "native";
+
+  if (isNative) {
+    return {
+      title: "XLM - Stellar Lumens",
+      description: "XLM (Stellar Lumens) is the native asset of the Stellar network.",
+    };
+  }
+
+  const shortIssuer = truncateHash(issuer, 4, 4);
+
+  if (!asset) {
+    return {
+      title: `${code} Asset`,
+      description: `View details of ${code} asset on Stellar. Issuer: ${shortIssuer}. Explore supply, holders, and flags.`,
+    };
+  }
+
+  return {
+    title: `${code} Asset | ${formatCompactNumber(asset.num_accounts ?? 0)} holders`,
+    description: `Explore ${code} on Stellar with ${formatCompactNumber(asset.num_accounts ?? 0)} holding accounts, ${formatCompactNumber(asset.amount ?? 0)} estimated supply, and issuer ${shortIssuer}.`,
+  };
+}
+
+export function buildContractMetadataCopy(
+  id: string,
+  contractCode?: { type: "sac" | "wasm"; codeSize: number } | null
+) {
+  const shortId = truncateHash(id, 6, 6);
+
+  if (!contractCode) {
+    return {
+      title: `Contract ${shortId}`,
+      description: `View Soroban smart contract ${shortId}. Explore events, storage, and contract code on Stellar.`,
+    };
+  }
+
+  if (contractCode.type === "sac") {
+    return {
+      title: `Contract ${shortId} | Stellar Asset Contract`,
+      description: `Inspect Stellar Asset Contract ${shortId}. Review standard token activity, storage, and recent transactions on Stellar.`,
+    };
+  }
+
+  return {
+    title: `Contract ${shortId} | Custom Soroban WASM`,
+    description: `Inspect Soroban contract ${shortId} with custom WASM bytecode (${formatCompactNumber(contractCode.codeSize)} bytes), storage, events, and recent transaction activity.`,
+  };
+}

--- a/src/lib/stellar/server.ts
+++ b/src/lib/stellar/server.ts
@@ -3,6 +3,7 @@ import type { Horizon } from "@stellar/stellar-sdk";
 import { getHorizonClient } from "@/lib/stellar/client";
 import { POPULAR_ASSETS } from "@/lib/constants";
 import type { NetworkKey } from "@/types";
+import { getRpcClient } from "./client";
 
 export const getLatestLedgerSnapshot = cache(async (network: NetworkKey) => {
   const horizon = getHorizonClient(network);
@@ -41,6 +42,54 @@ export const getAssetSnapshot = cache(async (network: NetworkKey, code: string, 
   const horizon = getHorizonClient(network);
   const response = await horizon.assets().forCode(code).forIssuer(issuer).call();
   return response.records[0] ?? null;
+});
+
+export const getContractCodeSnapshot = cache(async (network: NetworkKey, contractId: string) => {
+  const { Contract, xdr } = await import("@stellar/stellar-sdk");
+
+  const contract = new Contract(contractId);
+  const contractInstanceKey = xdr.LedgerKey.contractData(
+    new xdr.LedgerKeyContractData({
+      contract: contract.address().toScAddress(),
+      key: xdr.ScVal.scvLedgerKeyContractInstance(),
+      durability: xdr.ContractDataDurability.persistent(),
+    })
+  );
+
+  const rpc = getRpcClient(network);
+  const instanceResponse = await rpc.getLedgerEntries(contractInstanceKey);
+
+  if (!instanceResponse.entries || instanceResponse.entries.length === 0) {
+    return null;
+  }
+
+  const instanceEntry = instanceResponse.entries[0];
+  const contractData = instanceEntry.val.contractData();
+  const contractInstance = contractData.val().instance();
+  const executable = contractInstance.executable();
+
+  if (executable.switch().name !== "contractExecutableWasm") {
+    return {
+      type: "sac" as const,
+      codeSize: 0,
+    };
+  }
+
+  const wasmHash = executable.wasmHash();
+  const wasmCodeKey = xdr.LedgerKey.contractCode(new xdr.LedgerKeyContractCode({ hash: wasmHash }));
+  const codeResponse = await rpc.getLedgerEntries(wasmCodeKey);
+
+  if (!codeResponse.entries || codeResponse.entries.length === 0) {
+    return null;
+  }
+
+  const codeEntry = codeResponse.entries[0];
+  const contractCode = codeEntry.val.contractCode();
+
+  return {
+    type: "wasm" as const,
+    codeSize: contractCode.code().length,
+  };
 });
 
 export const getTopAssetSnapshots = cache(async (network: NetworkKey) => {


### PR DESCRIPTION
## Summary
This pull request enriches the explorer's entity detail pages with concise, human-readable context while preserving the existing premium, inspection-first interface.

It introduces contextual summaries for transaction, account, ledger, asset, and contract pages, and upgrades entity metadata so titles and descriptions reflect real on-chain attributes instead of generic fallback copy.

## What Changed
- added reusable contextual summary UI for entity detail pages
- introduced dynamic metadata generation for transaction, account, ledger, asset, and contract routes
- added server-side snapshot support required to build metadata from live entity attributes
- localized the new contextual copy across all supported locales

## Validation
- `bun install`
- `bun run lint`
- `bun run test`
- `bun run build`

## Notes For Review
- the production build completed successfully after allowing network access for `next/font` to fetch Geist and Geist Mono in this environment
- this branch is based directly on `chore/improve-seo`

Closes #26
