### PR TITLE
fix(ui): repair chart tooltip readability and broken theme color tokens

### DIFF
--- a/apps/explorer-web/messages/de.json
+++ b/apps/explorer-web/messages/de.json
@@ -452,6 +452,7 @@
     "opsPerLedger": "Operationen pro Ledger",
     "avgOps": "Durchschn. {count} Ops/Ledger",
     "operationsLabel": "Operationen",
+    "ledgerLabel": "Ledger",
     "transactionsLabel": "Transaktionen",
     "successful": "Erfolgreich",
     "total": "Gesamt",

--- a/apps/explorer-web/messages/en.json
+++ b/apps/explorer-web/messages/en.json
@@ -452,6 +452,7 @@
     "opsPerLedger": "Operations per Ledger",
     "avgOps": "Avg {count} ops/ledger",
     "operationsLabel": "Operations",
+    "ledgerLabel": "Ledger",
     "transactionsLabel": "Transactions",
     "successful": "Successful",
     "total": "Total",

--- a/apps/explorer-web/messages/es.json
+++ b/apps/explorer-web/messages/es.json
@@ -452,6 +452,7 @@
     "opsPerLedger": "Operaciones por Registro",
     "avgOps": "Promedio {count} ops/registro",
     "operationsLabel": "Operaciones",
+    "ledgerLabel": "Libro",
     "transactionsLabel": "Transacciones",
     "successful": "Exitosas",
     "total": "Total",

--- a/apps/explorer-web/messages/fr.json
+++ b/apps/explorer-web/messages/fr.json
@@ -452,6 +452,7 @@
     "opsPerLedger": "Opérations par Registre",
     "avgOps": "Moy. {count} ops/registre",
     "operationsLabel": "Opérations",
+    "ledgerLabel": "Registre",
     "transactionsLabel": "Transactions",
     "successful": "Réussies",
     "total": "Total",

--- a/apps/explorer-web/messages/it.json
+++ b/apps/explorer-web/messages/it.json
@@ -452,6 +452,7 @@
     "opsPerLedger": "Operazioni per Registro",
     "avgOps": "Media {count} ops/registro",
     "operationsLabel": "Operazioni",
+    "ledgerLabel": "Registro",
     "transactionsLabel": "Transazioni",
     "successful": "Riuscite",
     "total": "Totale",

--- a/apps/explorer-web/messages/ja.json
+++ b/apps/explorer-web/messages/ja.json
@@ -452,6 +452,7 @@
     "opsPerLedger": "レジャーあたりの操作数",
     "avgOps": "平均 {count} 操作/レジャー",
     "operationsLabel": "操作",
+    "ledgerLabel": "レジャー",
     "transactionsLabel": "トランザクション",
     "successful": "成功",
     "total": "合計",

--- a/apps/explorer-web/messages/ko.json
+++ b/apps/explorer-web/messages/ko.json
@@ -452,6 +452,7 @@
     "opsPerLedger": "원장당 작업 수",
     "avgOps": "평균 {count} 작업/원장",
     "operationsLabel": "작업",
+    "ledgerLabel": "원장",
     "transactionsLabel": "트랜잭션",
     "successful": "성공",
     "total": "전체",

--- a/apps/explorer-web/messages/pt.json
+++ b/apps/explorer-web/messages/pt.json
@@ -452,6 +452,7 @@
     "opsPerLedger": "Operações por Ledger",
     "avgOps": "Média {count} ops/ledger",
     "operationsLabel": "Operações",
+    "ledgerLabel": "Livro",
     "transactionsLabel": "Transações",
     "successful": "Bem-sucedidas",
     "total": "Total",

--- a/apps/explorer-web/messages/zh.json
+++ b/apps/explorer-web/messages/zh.json
@@ -452,6 +452,7 @@
     "opsPerLedger": "每账本操作数",
     "avgOps": "平均 {count} 操作/账本",
     "operationsLabel": "操作",
+    "ledgerLabel": "账本",
     "transactionsLabel": "交易",
     "successful": "成功",
     "total": "总计",

--- a/apps/explorer-web/src/components/charts/chart-config.ts
+++ b/apps/explorer-web/src/components/charts/chart-config.ts
@@ -1,12 +1,13 @@
-// Chart colors - hex values that work with Recharts SVG rendering
-// Softer, desaturated tones that work well in dark mode without being too aggressive
+// Chart series colors. These reference the theme's `--chart-*` tokens so the
+// data series adapt to light/dark mode and stay consistent with the header
+// numbers (text-chart-1/2/3). Recharts accepts CSS `var()` in stroke/fill/stopColor.
 export const chartColors = {
-  primary: "#7dd3fc", // Soft sky blue - for TPS chart
-  success: "#86efac", // Soft mint green - for transaction volume
-  warning: "#67e8f9", // Soft cyan - for fees
-  purple: "#d8b4fe", // Soft lavender - for contracts
-  red: "#fca5a5", // Soft coral - for failed transactions
-  muted: "#a1a1aa", // Zinc gray - for muted elements
+  primary: "var(--chart-1)", // Blue - for TPS chart and operations
+  success: "var(--chart-2)", // Green - for transaction volume
+  warning: "var(--chart-3)", // Cyan - for fees
+  purple: "var(--chart-4)", // Purple - for contracts
+  red: "var(--chart-5)", // Red - for failed transactions
+  muted: "var(--muted-foreground)", // Muted elements
 };
 
 export const chartConfig = {
@@ -17,22 +18,24 @@ export const chartConfig = {
   txAccumulationHours: 24,
 };
 
-// Common chart styling
+// Common chart styling.
+// Theme tokens are stored as raw color values (oklch), so reference them with
+// `var(--token)` directly — wrapping them in `hsl(...)` produces an invalid color.
 export const chartAxisStyle = {
   fontSize: 10,
-  fill: "hsl(var(--muted-foreground))",
+  fill: "var(--muted-foreground)",
   fontFamily: "inherit",
 };
 
 export const chartGridStyle = {
   strokeDasharray: "3 3",
-  stroke: "hsl(var(--border))",
+  stroke: "var(--border)",
   strokeOpacity: 0.5,
 };
 
 export const chartTooltipStyle = {
-  backgroundColor: "hsl(var(--popover))",
-  border: "1px solid hsl(var(--border))",
+  backgroundColor: "var(--popover)",
+  border: "1px solid var(--border)",
   borderRadius: "8px",
   padding: "8px 12px",
   boxShadow: "0 4px 6px -1px rgb(0 0 0 / 0.1)",

--- a/apps/explorer-web/src/components/charts/operations-chart.tsx
+++ b/apps/explorer-web/src/components/charts/operations-chart.tsx
@@ -5,13 +5,36 @@ import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContaine
 import { ChartWrapper } from "./chart-wrapper";
 import { useOpsPerLedgerChartData } from "@/lib/hooks/use-chart-data";
 import { useTranslations } from "next-intl";
-import {
-  chartColors,
-  chartConfig,
-  chartAxisStyle,
-  chartGridStyle,
-  chartTooltipStyle,
-} from "./chart-config";
+import { chartColors, chartConfig, chartAxisStyle, chartGridStyle } from "./chart-config";
+
+interface TooltipProps {
+  active?: boolean;
+  payload?: Array<{ value: number; payload: { ledger: number } }>;
+  ledgerLabel?: string;
+  operationsLabel?: string;
+}
+
+function CustomTooltip({
+  active,
+  payload,
+  ledgerLabel = "Ledger",
+  operationsLabel = "Operations",
+}: TooltipProps) {
+  if (!active || !payload?.length) return null;
+
+  const { ledger } = payload[0].payload;
+
+  return (
+    <div className="bg-popover border-border rounded-lg border px-3 py-2 shadow-lg">
+      <p className="text-foreground text-sm font-medium">
+        {ledgerLabel} #{Number(ledger).toLocaleString()}
+      </p>
+      <p className="text-muted-foreground text-xs">
+        {operationsLabel}: {Number(payload[0].value).toLocaleString()}
+      </p>
+    </div>
+  );
+}
 
 export default function OperationsChart() {
   const { data, avgOps, isLoading } = useOpsPerLedgerChartData();
@@ -41,12 +64,13 @@ export default function OperationsChart() {
             />
             <YAxis {...chartAxisStyle} />
             <Tooltip
-              contentStyle={chartTooltipStyle}
-              labelFormatter={(v) => `Ledger #${Number(v).toLocaleString()}`}
-              formatter={(value, name) => [
-                Number(value).toLocaleString(),
-                name === "ops" ? t("operationsLabel") : t("transactionsLabel"),
-              ]}
+              cursor={{ fill: "var(--muted)", opacity: 0.4 }}
+              content={
+                <CustomTooltip
+                  ledgerLabel={t("ledgerLabel")}
+                  operationsLabel={t("operationsLabel")}
+                />
+              }
             />
             <Bar dataKey="ops" fill={chartColors.primary} radius={[4, 4, 0, 0]} opacity={0.85} />
           </BarChart>

--- a/apps/explorer-web/src/components/layout/stellar-icon.tsx
+++ b/apps/explorer-web/src/components/layout/stellar-icon.tsx
@@ -32,8 +32,8 @@ export function StellarLogo({ className }: { className?: string }) {
     >
       <defs>
         <linearGradient id="stellar-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="hsl(var(--primary))" />
-          <stop offset="100%" stopColor="hsl(var(--chart-1))" />
+          <stop offset="0%" stopColor="var(--primary)" />
+          <stop offset="100%" stopColor="var(--chart-1)" />
         </linearGradient>
       </defs>
       <circle cx="50" cy="50" r="48" fill="url(#stellar-gradient)" />

--- a/apps/explorer-web/src/lib/providers/index.tsx
+++ b/apps/explorer-web/src/lib/providers/index.tsx
@@ -3,10 +3,27 @@
 import type { ReactNode } from "react";
 import { QueryProvider } from "./query-provider";
 import { NetworkProvider } from "./network-provider";
-import { ThemeProvider } from "./theme-provider";
+import { ThemeProvider, useTheme } from "./theme-provider";
 import { DeveloperModeProvider } from "./developer-mode-provider";
 import { AnalyticsModeProvider } from "./analytics-mode-provider";
 import { Toaster } from "sonner";
+
+function ThemedToaster() {
+  const { resolvedTheme } = useTheme();
+  return (
+    <Toaster
+      position="bottom-right"
+      theme={resolvedTheme}
+      toastOptions={{
+        style: {
+          background: "var(--card)",
+          border: "1px solid var(--border)",
+          color: "var(--foreground)",
+        },
+      }}
+    />
+  );
+}
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
@@ -16,17 +33,7 @@ export function Providers({ children }: { children: ReactNode }) {
           <DeveloperModeProvider>
             <AnalyticsModeProvider>
               {children}
-              <Toaster
-                position="bottom-right"
-                theme="dark"
-                toastOptions={{
-                  style: {
-                    background: "hsl(var(--card))",
-                    border: "1px solid hsl(var(--border))",
-                    color: "hsl(var(--foreground))",
-                  },
-                }}
-              />
+              <ThemedToaster />
             </AnalyticsModeProvider>
           </DeveloperModeProvider>
         </NetworkProvider>


### PR DESCRIPTION
- Operations per Ledger chart now uses a custom tooltip (theme-aware text) instead of the default Recharts tooltip, whose value text inherited the pale series color and was unreadable on the popover
- Fix invalid hsl(var(--token)) usages left over from the oklch theme migration in chart axes/grid/tooltip, the Stellar logo gradient, and the Sonner toaster (these produced invalid colors)
- Drive chart series colors from --chart-* tokens so data is legible in both light and dark mode and consistent with header figures
- Make the toaster theme-aware via resolvedTheme
- Add charts.ledgerLabel translation across all 9 locales