### PR TITLE
Unify branding to StellarView

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Tests use happy-dom environment. Test files live alongside source as `*.test.{ts
 
 ## Architecture
 
-Stellar Explorer is a Next.js 16 App Router application that provides a blockchain explorer for the Stellar network. It uses Bun as its package manager.
+StellarView Explorer is a Next.js 16 App Router application that provides a blockchain explorer for the Stellar network. It uses Bun as its package manager.
 
 ### Routing: `src/app/[locale]/[network]/(explorer)/...`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Stellar Explorer
+# Contributing to StellarView Explorer
 
 Thank you for your interest in contributing. This guide covers the essentials for getting your changes merged.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Stellar View | Stellar Explorer
+# StellarView Explorer
 
 > A premium block explorer for the Stellar network — built for developers, traders, and ecosystem builders.
 
@@ -8,11 +8,11 @@
 
 ## Overview
 
-Stellar Explorer gives you a fast, clean window into the Stellar blockchain. Browse ledgers, transactions, accounts, assets, and Soroban smart contracts across **Public**, **Testnet**, and **Futurenet** — all in one place.
+StellarView Explorer gives you a fast, clean window into the Stellar blockchain. Browse ledgers, transactions, accounts, assets, and Soroban smart contracts across **Public**, **Testnet**, and **Futurenet** — all in one place.
 
 The app is **live today**, powered entirely by the Stellar Horizon API and Soroban RPC.
 
-This repository holds the **web app** only. Stellar Explorer also ships a custom indexer and a terminal client, each in their own repository:
+This repository holds the **web app** only. StellarView Explorer also ships a custom indexer and a terminal client, each in their own repository:
 
 | Repo | What it is |
 | --- | --- |

--- a/apps/explorer-web/messages/de.json
+++ b/apps/explorer-web/messages/de.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "title": "Stellar View | Stellar Explorer",
-    "description": "Stellar View ist ein Open-Source Stellar Explorer — erkunden Sie Ledger, Transaktionen, Konten, Assets und Soroban Smart Contracts im Stellar-Netzwerk. Unterstützt Mainnet, Testnet und Futurenet.",
-    "brand": "Stellar View"
+    "title": "StellarView Explorer",
+    "description": "StellarView ist ein Open-Source Stellar Explorer — erkunden Sie Ledger, Transaktionen, Konten, Assets und Soroban Smart Contracts im Stellar-Netzwerk. Unterstützt Mainnet, Testnet und Futurenet.",
+    "brand": "StellarView"
   },
   "navigation": {
     "overview": "Übersicht",
@@ -97,7 +97,7 @@
     "contractsDesc": "Soroban erkunden"
   },
   "transactions": {
-    "metaTitle": "Transaktionen | Stellar Explorer",
+    "metaTitle": "Transaktionen | StellarView Explorer",
     "metaDescription": "Durchsuchen Sie aktuelle Transaktionen im Stellar-Netzwerk. Sehen Sie Transaktionsdetails, Operationen und mehr.",
     "title": "Transaktionen",
     "recentTransactions": "Kürzliche Transaktionen",
@@ -106,7 +106,7 @@
     "noRecentFound": "Keine kürzlichen Transaktionen in diesem Netzwerk gefunden."
   },
   "ledgers": {
-    "metaTitle": "Ledger | Stellar Explorer",
+    "metaTitle": "Ledger | StellarView Explorer",
     "metaDescription": "Durchsuchen Sie die Ledger-Historie im Stellar-Netzwerk. Suchen und erkunden Sie einzelne Ledger.",
     "title": "Ledger",
     "searchLedger": "Ledger suchen",
@@ -130,7 +130,7 @@
     "accountsDescription": "Geben Sie eine Stellar-Adresse ein, um Kontodetails, Guthaben, Transaktionen und Signer-Informationen anzuzeigen."
   },
   "assets": {
-    "metaTitle": "Assets | Stellar Explorer",
+    "metaTitle": "Assets | StellarView Explorer",
     "metaDescription": "Erkunden Sie Assets im Stellar-Netzwerk. Sehen Sie Top-Assets, suchen Sie nach Code oder Emittent.",
     "title": "Assets",
     "subtitle": "Erkunden Sie Tokens und Assets im Stellar-Netzwerk",
@@ -159,7 +159,7 @@
     "price": "Preis"
   },
   "contracts": {
-    "metaTitle": "Smart Contracts | Stellar Explorer",
+    "metaTitle": "Smart Contracts | StellarView Explorer",
     "metaDescription": "Erkunden Sie Soroban Smart Contracts im Stellar-Netzwerk. Suchen und sehen Sie Vertragsdetails.",
     "title": "Smart Contracts",
     "subtitle": "Erkunden Sie Soroban Smart Contracts im Stellar-Netzwerk",
@@ -565,7 +565,7 @@
     "stellar": "Stellar"
   },
   "mobileNav": {
-    "stellarExplorer": "Stellar Explorer"
+    "stellarExplorer": "StellarView Explorer"
   },
   "accessibility": {
     "changeLanguage": "Sprache ändern"

--- a/apps/explorer-web/messages/en.json
+++ b/apps/explorer-web/messages/en.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "title": "Stellar View | Stellar Explorer",
-    "description": "Stellar View is an open-source Stellar Explorer — browse ledgers, transactions, accounts, assets, and Soroban smart contracts across the Stellar network. Supports Public, Testnet, and Futurenet.",
-    "brand": "Stellar View"
+    "title": "StellarView Explorer",
+    "description": "StellarView is an open-source Stellar Explorer — browse ledgers, transactions, accounts, assets, and Soroban smart contracts across the Stellar network. Supports Public, Testnet, and Futurenet.",
+    "brand": "StellarView"
   },
   "navigation": {
     "overview": "Overview",
@@ -97,7 +97,7 @@
     "contractsDesc": "Explore Soroban"
   },
   "transactions": {
-    "metaTitle": "Transactions | Stellar Explorer",
+    "metaTitle": "Transactions | StellarView Explorer",
     "metaDescription": "Browse recent transactions on the Stellar network. View transaction details, operations, and more.",
     "title": "Transactions",
     "recentTransactions": "Recent Transactions",
@@ -106,7 +106,7 @@
     "noRecentFound": "No recent transactions found on this network."
   },
   "ledgers": {
-    "metaTitle": "Ledgers | Stellar Explorer",
+    "metaTitle": "Ledgers | StellarView Explorer",
     "metaDescription": "Browse ledger history on the Stellar network. Search and explore individual ledgers.",
     "title": "Ledgers",
     "searchLedger": "Search Ledger",
@@ -130,7 +130,7 @@
     "accountsDescription": "Enter a Stellar address to view account details, balances, transactions, and signing information."
   },
   "assets": {
-    "metaTitle": "Assets | Stellar Explorer",
+    "metaTitle": "Assets | StellarView Explorer",
     "metaDescription": "Explore assets on the Stellar network. View top assets, search by code or issuer.",
     "title": "Assets",
     "subtitle": "Explore tokens and assets on the Stellar network",
@@ -159,7 +159,7 @@
     "price": "Price"
   },
   "contracts": {
-    "metaTitle": "Smart Contracts | Stellar Explorer",
+    "metaTitle": "Smart Contracts | StellarView Explorer",
     "metaDescription": "Explore Soroban smart contracts on the Stellar network. Search and view contract details.",
     "title": "Smart Contracts",
     "subtitle": "Explore Soroban smart contracts on the Stellar network",
@@ -611,7 +611,7 @@
     "stellar": "Stellar"
   },
   "mobileNav": {
-    "stellarExplorer": "Stellar Explorer"
+    "stellarExplorer": "StellarView Explorer"
   },
   "accessibility": {
     "changeLanguage": "Change language"

--- a/apps/explorer-web/messages/es.json
+++ b/apps/explorer-web/messages/es.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "title": "Stellar View | Stellar Explorer",
-    "description": "Stellar View es un Stellar Explorer de código abierto — explora ledgers, transacciones, cuentas, activos y contratos inteligentes Soroban en la red Stellar. Compatible con Mainnet, Testnet y Futurenet.",
-    "brand": "Stellar View"
+    "title": "StellarView Explorer",
+    "description": "StellarView es un Stellar Explorer de código abierto — explora ledgers, transacciones, cuentas, activos y contratos inteligentes Soroban en la red Stellar. Compatible con Mainnet, Testnet y Futurenet.",
+    "brand": "StellarView"
   },
   "navigation": {
     "overview": "Inicio",
@@ -97,7 +97,7 @@
     "contractsDesc": "Explorar Soroban"
   },
   "transactions": {
-    "metaTitle": "Transacciones | Stellar Explorer",
+    "metaTitle": "Transacciones | StellarView Explorer",
     "metaDescription": "Explora transacciones recientes en la red Stellar. Ve detalles de transacciones, operaciones y más.",
     "title": "Transacciones",
     "recentTransactions": "Transacciones recientes",
@@ -106,7 +106,7 @@
     "noRecentFound": "No se encontraron transacciones recientes en esta red."
   },
   "ledgers": {
-    "metaTitle": "Libros | Stellar Explorer",
+    "metaTitle": "Libros | StellarView Explorer",
     "metaDescription": "Explora el historial de libros en la red Stellar. Busca y explora libros individuales.",
     "title": "Libros",
     "searchLedger": "Buscar libro",
@@ -130,7 +130,7 @@
     "accountsDescription": "Ingresa una dirección Stellar para ver detalles de la cuenta, balances, transacciones e información de firmantes."
   },
   "assets": {
-    "metaTitle": "Activos | Stellar Explorer",
+    "metaTitle": "Activos | StellarView Explorer",
     "metaDescription": "Explora activos en la red Stellar. Ve los principales activos, busca por código o emisor.",
     "title": "Activos",
     "subtitle": "Explora tokens y activos en la red Stellar",
@@ -159,7 +159,7 @@
     "price": "Precio"
   },
   "contracts": {
-    "metaTitle": "Contratos inteligentes | Stellar Explorer",
+    "metaTitle": "Contratos inteligentes | StellarView Explorer",
     "metaDescription": "Explora contratos inteligentes Soroban en la red Stellar. Busca y ve detalles de contratos.",
     "title": "Contratos inteligentes",
     "subtitle": "Explora contratos inteligentes Soroban en la red Stellar",

--- a/apps/explorer-web/messages/fr.json
+++ b/apps/explorer-web/messages/fr.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "title": "Stellar View | Stellar Explorer",
-    "description": "Stellar View est un Stellar Explorer open-source — explorez les ledgers, transactions, comptes, actifs et contrats intelligents Soroban sur le réseau Stellar. Compatible Mainnet, Testnet et Futurenet.",
-    "brand": "Stellar View"
+    "title": "StellarView Explorer",
+    "description": "StellarView est un Stellar Explorer open-source — explorez les ledgers, transactions, comptes, actifs et contrats intelligents Soroban sur le réseau Stellar. Compatible Mainnet, Testnet et Futurenet.",
+    "brand": "StellarView"
   },
   "navigation": {
     "overview": "Aperçu",
@@ -97,7 +97,7 @@
     "contractsDesc": "Explorer Soroban"
   },
   "transactions": {
-    "metaTitle": "Transactions | Stellar Explorer",
+    "metaTitle": "Transactions | StellarView Explorer",
     "metaDescription": "Parcourez les transactions récentes sur le réseau Stellar. Consultez les détails des transactions, opérations et plus.",
     "title": "Transactions",
     "recentTransactions": "Transactions Récentes",
@@ -106,7 +106,7 @@
     "noRecentFound": "Aucune transaction récente trouvée sur ce réseau."
   },
   "ledgers": {
-    "metaTitle": "Registres | Stellar Explorer",
+    "metaTitle": "Registres | StellarView Explorer",
     "metaDescription": "Parcourez l'historique des registres sur le réseau Stellar. Recherchez et explorez des registres individuels.",
     "title": "Registres",
     "searchLedger": "Rechercher un Registre",
@@ -130,7 +130,7 @@
     "accountsDescription": "Entrez une adresse Stellar pour voir les détails du compte, les soldes, les transactions et les informations des signataires."
   },
   "assets": {
-    "metaTitle": "Actifs | Stellar Explorer",
+    "metaTitle": "Actifs | StellarView Explorer",
     "metaDescription": "Explorez les actifs sur le réseau Stellar. Consultez les principaux actifs, recherchez par code ou émetteur.",
     "title": "Actifs",
     "subtitle": "Explorez les tokens et actifs sur le réseau Stellar",
@@ -159,7 +159,7 @@
     "price": "Prix"
   },
   "contracts": {
-    "metaTitle": "Contrats Intelligents | Stellar Explorer",
+    "metaTitle": "Contrats Intelligents | StellarView Explorer",
     "metaDescription": "Explorez les contrats intelligents Soroban sur le réseau Stellar. Recherchez et consultez les détails des contrats.",
     "title": "Contrats Intelligents",
     "subtitle": "Explorez les contrats intelligents Soroban sur le réseau Stellar",

--- a/apps/explorer-web/messages/it.json
+++ b/apps/explorer-web/messages/it.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "title": "Stellar View | Stellar Explorer",
-    "description": "Stellar View è uno Stellar Explorer open-source — esplora ledger, transazioni, account, asset e smart contract Soroban sulla rete Stellar. Supporta Mainnet, Testnet e Futurenet.",
-    "brand": "Stellar View"
+    "title": "StellarView Explorer",
+    "description": "StellarView è uno Stellar Explorer open-source — esplora ledger, transazioni, account, asset e smart contract Soroban sulla rete Stellar. Supporta Mainnet, Testnet e Futurenet.",
+    "brand": "StellarView"
   },
   "navigation": {
     "overview": "Panoramica",
@@ -97,7 +97,7 @@
     "contractsDesc": "Esplora Soroban"
   },
   "transactions": {
-    "metaTitle": "Transazioni | Stellar Explorer",
+    "metaTitle": "Transazioni | StellarView Explorer",
     "metaDescription": "Sfoglia le transazioni recenti sulla rete Stellar. Visualizza i dettagli delle transazioni, le operazioni e altro.",
     "title": "Transazioni",
     "recentTransactions": "Transazioni recenti",
@@ -106,7 +106,7 @@
     "noRecentFound": "Nessuna transazione recente trovata su questa rete."
   },
   "ledgers": {
-    "metaTitle": "Registri | Stellar Explorer",
+    "metaTitle": "Registri | StellarView Explorer",
     "metaDescription": "Sfoglia la cronologia dei registri sulla rete Stellar. Cerca ed esplora i singoli registri.",
     "title": "Registri",
     "searchLedger": "Cerca registro",
@@ -130,7 +130,7 @@
     "accountsDescription": "Inserisci un indirizzo Stellar per visualizzare i dettagli del conto, i saldi, le transazioni e le informazioni di firma."
   },
   "assets": {
-    "metaTitle": "Risorse | Stellar Explorer",
+    "metaTitle": "Risorse | StellarView Explorer",
     "metaDescription": "Esplora le risorse sulla rete Stellar. Visualizza le risorse principali, cerca per codice o emittente.",
     "title": "Risorse",
     "subtitle": "Esplora token e risorse sulla rete Stellar",
@@ -159,7 +159,7 @@
     "price": "Prezzo"
   },
   "contracts": {
-    "metaTitle": "Smart Contract | Stellar Explorer",
+    "metaTitle": "Smart Contract | StellarView Explorer",
     "metaDescription": "Esplora gli smart contract Soroban sulla rete Stellar. Cerca e visualizza i dettagli dei contratti.",
     "title": "Smart Contract",
     "subtitle": "Esplora gli smart contract Soroban sulla rete Stellar",
@@ -611,7 +611,7 @@
     "stellar": "Stellar"
   },
   "mobileNav": {
-    "stellarExplorer": "Stellar Explorer"
+    "stellarExplorer": "StellarView Explorer"
   },
   "accessibility": {
     "changeLanguage": "Cambia lingua"

--- a/apps/explorer-web/messages/ja.json
+++ b/apps/explorer-web/messages/ja.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "title": "Stellar View | Stellar Explorer",
-    "description": "Stellar View はオープンソースの Stellar Explorer です。Stellar ネットワーク上の台帳、トランザクション、アカウント、資産、Soroban スマートコントラクトを閲覧できます。Mainnet・Testnet・Futurenet 対応。",
-    "brand": "Stellar View"
+    "title": "StellarView Explorer",
+    "description": "StellarView はオープンソースの Stellar Explorer です。Stellar ネットワーク上の台帳、トランザクション、アカウント、資産、Soroban スマートコントラクトを閲覧できます。Mainnet・Testnet・Futurenet 対応。",
+    "brand": "StellarView"
   },
   "navigation": {
     "overview": "概要",
@@ -97,7 +97,7 @@
     "contractsDesc": "Sorobanを探索"
   },
   "transactions": {
-    "metaTitle": "トランザクション | Stellar Explorer",
+    "metaTitle": "トランザクション | StellarView Explorer",
     "metaDescription": "Stellarネットワーク上の最近のトランザクションを閲覧。トランザクションの詳細、操作などを表示。",
     "title": "トランザクション",
     "recentTransactions": "最近のトランザクション",
@@ -106,7 +106,7 @@
     "noRecentFound": "このネットワークで最近のトランザクションは見つかりませんでした。"
   },
   "ledgers": {
-    "metaTitle": "レジャー | Stellar Explorer",
+    "metaTitle": "レジャー | StellarView Explorer",
     "metaDescription": "Stellarネットワーク上のレジャー履歴を閲覧。個々のレジャーを検索・探索。",
     "title": "レジャー",
     "searchLedger": "レジャーを検索",
@@ -130,7 +130,7 @@
     "accountsDescription": "Stellarアドレスを入力して、アカウント詳細、残高、トランザクション、署名者情報を表示。"
   },
   "assets": {
-    "metaTitle": "アセット | Stellar Explorer",
+    "metaTitle": "アセット | StellarView Explorer",
     "metaDescription": "Stellarネットワーク上のアセットを探索。トップアセットを表示、コードや発行者で検索。",
     "title": "アセット",
     "subtitle": "Stellarネットワーク上のトークンとアセットを探索",
@@ -159,7 +159,7 @@
     "price": "価格"
   },
   "contracts": {
-    "metaTitle": "スマートコントラクト | Stellar Explorer",
+    "metaTitle": "スマートコントラクト | StellarView Explorer",
     "metaDescription": "Stellarネットワーク上のSorobanスマートコントラクトを探索。コントラクトの詳細を検索・表示。",
     "title": "スマートコントラクト",
     "subtitle": "Stellarネットワーク上のSorobanスマートコントラクトを探索",

--- a/apps/explorer-web/messages/ko.json
+++ b/apps/explorer-web/messages/ko.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "title": "Stellar View | Stellar Explorer",
-    "description": "Stellar View는 오픈소스 Stellar Explorer입니다. Stellar 네트워크의 원장, 트랜잭션, 계정, 자산 및 Soroban 스마트 컨트랙트를 탐색하세요. Mainnet, Testnet, Futurenet 지원.",
-    "brand": "Stellar View"
+    "title": "StellarView Explorer",
+    "description": "StellarView는 오픈소스 Stellar Explorer입니다. Stellar 네트워크의 원장, 트랜잭션, 계정, 자산 및 Soroban 스마트 컨트랙트를 탐색하세요. Mainnet, Testnet, Futurenet 지원.",
+    "brand": "StellarView"
   },
   "navigation": {
     "overview": "개요",
@@ -97,7 +97,7 @@
     "contractsDesc": "Soroban 탐색"
   },
   "transactions": {
-    "metaTitle": "트랜잭션 | Stellar Explorer",
+    "metaTitle": "트랜잭션 | StellarView Explorer",
     "metaDescription": "Stellar 네트워크의 최근 트랜잭션을 탐색하세요. 트랜잭션 세부 정보, 오퍼레이션 등을 확인하세요.",
     "title": "트랜잭션",
     "recentTransactions": "최근 트랜잭션",
@@ -106,7 +106,7 @@
     "noRecentFound": "이 네트워크에서 최근 트랜잭션을 찾을 수 없습니다."
   },
   "ledgers": {
-    "metaTitle": "원장 | Stellar Explorer",
+    "metaTitle": "원장 | StellarView Explorer",
     "metaDescription": "Stellar 네트워크의 원장 기록을 탐색하세요. 개별 원장을 검색하고 탐색하세요.",
     "title": "원장",
     "searchLedger": "원장 검색",
@@ -130,7 +130,7 @@
     "accountsDescription": "Stellar 주소를 입력하여 계정 상세 정보, 잔액, 트랜잭션 및 서명자 정보를 확인하세요."
   },
   "assets": {
-    "metaTitle": "자산 | Stellar Explorer",
+    "metaTitle": "자산 | StellarView Explorer",
     "metaDescription": "Stellar 네트워크의 자산을 탐색하세요. 상위 자산을 보고, 코드 또는 발행자로 검색하세요.",
     "title": "자산",
     "subtitle": "Stellar 네트워크의 토큰과 자산 탐색",
@@ -159,7 +159,7 @@
     "price": "가격"
   },
   "contracts": {
-    "metaTitle": "스마트 컨트랙트 | Stellar Explorer",
+    "metaTitle": "스마트 컨트랙트 | StellarView Explorer",
     "metaDescription": "Stellar 네트워크의 Soroban 스마트 컨트랙트를 탐색하세요. 컨트랙트 세부 정보를 검색하고 확인하세요.",
     "title": "스마트 컨트랙트",
     "subtitle": "Stellar 네트워크의 Soroban 스마트 컨트랙트 탐색",
@@ -611,7 +611,7 @@
     "stellar": "Stellar"
   },
   "mobileNav": {
-    "stellarExplorer": "Stellar Explorer"
+    "stellarExplorer": "StellarView Explorer"
   },
   "accessibility": {
     "changeLanguage": "언어 변경"

--- a/apps/explorer-web/messages/pt.json
+++ b/apps/explorer-web/messages/pt.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "title": "Stellar View | Stellar Explorer",
-    "description": "Stellar View é um Stellar Explorer de código aberto — explore ledgers, transações, contas, ativos e contratos inteligentes Soroban na rede Stellar. Suporta Mainnet, Testnet e Futurenet.",
-    "brand": "Stellar View"
+    "title": "StellarView Explorer",
+    "description": "StellarView é um Stellar Explorer de código aberto — explore ledgers, transações, contas, ativos e contratos inteligentes Soroban na rede Stellar. Suporta Mainnet, Testnet e Futurenet.",
+    "brand": "StellarView"
   },
   "navigation": {
     "overview": "Visão Geral",
@@ -97,7 +97,7 @@
     "contractsDesc": "Explorar Soroban"
   },
   "transactions": {
-    "metaTitle": "Transações | Stellar Explorer",
+    "metaTitle": "Transações | StellarView Explorer",
     "metaDescription": "Explore transações recentes na rede Stellar. Veja detalhes de transações, operações e mais.",
     "title": "Transações",
     "recentTransactions": "Transações Recentes",
@@ -106,7 +106,7 @@
     "noRecentFound": "Nenhuma transação recente encontrada nesta rede."
   },
   "ledgers": {
-    "metaTitle": "Livros | Stellar Explorer",
+    "metaTitle": "Livros | StellarView Explorer",
     "metaDescription": "Explore o histórico de livros na rede Stellar. Busque e explore livros individuais.",
     "title": "Livros",
     "searchLedger": "Buscar Livro",
@@ -130,7 +130,7 @@
     "accountsDescription": "Digite um endereço Stellar para ver detalhes da conta, saldos, transações e informações de assinantes."
   },
   "assets": {
-    "metaTitle": "Ativos | Stellar Explorer",
+    "metaTitle": "Ativos | StellarView Explorer",
     "metaDescription": "Explore ativos na rede Stellar. Veja os principais ativos, busque por código ou emissor.",
     "title": "Ativos",
     "subtitle": "Explore tokens e ativos na rede Stellar",
@@ -159,7 +159,7 @@
     "price": "Preço"
   },
   "contracts": {
-    "metaTitle": "Contratos Inteligentes | Stellar Explorer",
+    "metaTitle": "Contratos Inteligentes | StellarView Explorer",
     "metaDescription": "Explore contratos inteligentes Soroban na rede Stellar. Busque e veja detalhes de contratos.",
     "title": "Contratos Inteligentes",
     "subtitle": "Explore contratos inteligentes Soroban na rede Stellar",

--- a/apps/explorer-web/messages/zh.json
+++ b/apps/explorer-web/messages/zh.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "title": "Stellar View | Stellar Explorer",
-    "description": "Stellar View 是开源的 Stellar Explorer — 浏览 Stellar 网络上的账本、交易、账户、资产和 Soroban 智能合约。支持主网、测试网和 Futurenet。",
-    "brand": "Stellar View"
+    "title": "StellarView Explorer",
+    "description": "StellarView 是开源的 Stellar Explorer — 浏览 Stellar 网络上的账本、交易、账户、资产和 Soroban 智能合约。支持主网、测试网和 Futurenet。",
+    "brand": "StellarView"
   },
   "navigation": {
     "overview": "概览",
@@ -97,7 +97,7 @@
     "contractsDesc": "探索 Soroban"
   },
   "transactions": {
-    "metaTitle": "交易 | Stellar Explorer",
+    "metaTitle": "交易 | StellarView Explorer",
     "metaDescription": "浏览 Stellar 网络上的最近交易。查看交易详情、操作等。",
     "title": "交易",
     "recentTransactions": "最近交易",
@@ -106,7 +106,7 @@
     "noRecentFound": "此网络未找到最近交易。"
   },
   "ledgers": {
-    "metaTitle": "账本 | Stellar Explorer",
+    "metaTitle": "账本 | StellarView Explorer",
     "metaDescription": "浏览 Stellar 网络上的账本历史。搜索和探索各个账本。",
     "title": "账本",
     "searchLedger": "搜索账本",
@@ -130,7 +130,7 @@
     "accountsDescription": "输入 Stellar 地址以查看账户详情、余额、交易和签名者信息。"
   },
   "assets": {
-    "metaTitle": "资产 | Stellar Explorer",
+    "metaTitle": "资产 | StellarView Explorer",
     "metaDescription": "探索 Stellar 网络上的资产。查看热门资产，按代码或发行方搜索。",
     "title": "资产",
     "subtitle": "探索 Stellar 网络上的代币和资产",
@@ -159,7 +159,7 @@
     "price": "价格"
   },
   "contracts": {
-    "metaTitle": "智能合约 | Stellar Explorer",
+    "metaTitle": "智能合约 | StellarView Explorer",
     "metaDescription": "探索 Stellar 网络上的 Soroban 智能合约。搜索和查看合约详情。",
     "title": "智能合约",
     "subtitle": "探索 Stellar 网络上的 Soroban 智能合约",

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/account/[id]/opengraph-image.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/account/[id]/opengraph-image.tsx
@@ -122,7 +122,7 @@ export default async function Image({ params }: { params: { id: string; locale: 
         </div>
       </div>
 
-      {/* Stellar Explorer branding */}
+      {/* StellarView Explorer branding */}
       <div
         style={{
           position: "absolute",
@@ -154,7 +154,7 @@ export default async function Image({ params }: { params: { id: string; locale: 
             <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
           </svg>
         </div>
-        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>Stellar Explorer</span>
+        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>StellarView Explorer</span>
       </div>
 
       {/* Bottom gradient */}

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/account/[id]/page.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/account/[id]/page.tsx
@@ -15,13 +15,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description: `View Stellar account ${shortId}. Explore balances, transactions, operations, and signers.`,
     openGraph: {
       title: `Stellar Account ${shortId}`,
-      description: `View account details on Stellar Explorer`,
+      description: `View account details on StellarView Explorer`,
       type: "website",
     },
     twitter: {
       card: "summary",
       title: `Stellar Account ${shortId}`,
-      description: `View account details on Stellar Explorer`,
+      description: `View account details on StellarView Explorer`,
     },
   };
 }

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/asset/[slug]/opengraph-image.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/asset/[slug]/opengraph-image.tsx
@@ -145,7 +145,7 @@ export default async function Image({ params }: { params: { slug: string; locale
         </div>
       </div>
 
-      {/* Stellar Explorer branding */}
+      {/* StellarView Explorer branding */}
       <div
         style={{
           position: "absolute",
@@ -177,7 +177,7 @@ export default async function Image({ params }: { params: { slug: string; locale
             <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
           </svg>
         </div>
-        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>Stellar Explorer</span>
+        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>StellarView Explorer</span>
       </div>
 
       {/* Bottom gradient */}

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/asset/[slug]/page.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/asset/[slug]/page.tsx
@@ -30,7 +30,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title: isNative ? "Stellar Lumens (XLM)" : `${code} - Stellar Asset`,
       description: isNative
         ? "Native asset of the Stellar network"
-        : `View ${code} asset details on Stellar Explorer`,
+        : `View ${code} asset details on StellarView Explorer`,
       type: "website",
     },
     twitter: {
@@ -38,7 +38,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title: isNative ? "Stellar Lumens (XLM)" : `${code} - Stellar Asset`,
       description: isNative
         ? "Native asset of the Stellar network"
-        : `View ${code} asset details on Stellar Explorer`,
+        : `View ${code} asset details on StellarView Explorer`,
     },
   };
 }

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/contract/[id]/opengraph-image.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/contract/[id]/opengraph-image.tsx
@@ -122,7 +122,7 @@ export default async function Image({ params }: { params: { id: string; locale: 
         </div>
       </div>
 
-      {/* Stellar Explorer branding */}
+      {/* StellarView Explorer branding */}
       <div
         style={{
           position: "absolute",
@@ -154,7 +154,7 @@ export default async function Image({ params }: { params: { id: string; locale: 
             <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
           </svg>
         </div>
-        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>Stellar Explorer</span>
+        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>StellarView Explorer</span>
       </div>
 
       {/* Bottom gradient */}

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/contract/[id]/page.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/contract/[id]/page.tsx
@@ -15,13 +15,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description: `View Soroban smart contract ${shortId}. Explore events, storage, and contract code on Stellar.`,
     openGraph: {
       title: `Soroban Contract ${shortId}`,
-      description: `View smart contract details on Stellar Explorer`,
+      description: `View smart contract details on StellarView Explorer`,
       type: "website",
     },
     twitter: {
       card: "summary",
       title: `Soroban Contract ${shortId}`,
-      description: `View smart contract details on Stellar Explorer`,
+      description: `View smart contract details on StellarView Explorer`,
     },
   };
 }

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/ledger/[sequence]/opengraph-image.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/ledger/[sequence]/opengraph-image.tsx
@@ -125,7 +125,7 @@ export default async function Image({ params }: { params: { sequence: string; lo
         </div>
       </div>
 
-      {/* Stellar Explorer branding */}
+      {/* StellarView Explorer branding */}
       <div
         style={{
           position: "absolute",
@@ -157,7 +157,7 @@ export default async function Image({ params }: { params: { sequence: string; lo
             <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
           </svg>
         </div>
-        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>Stellar Explorer</span>
+        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>StellarView Explorer</span>
       </div>
 
       {/* Bottom gradient */}

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/ledger/[sequence]/page.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/ledger/[sequence]/page.tsx
@@ -23,13 +23,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description: `View details of Stellar ledger #${formattedSequence}. Explore transactions, operations, and protocol information.`,
     openGraph: {
       title: `Stellar Ledger #${formattedSequence}`,
-      description: `View ledger details on Stellar Explorer`,
+      description: `View ledger details on StellarView Explorer`,
       type: "website",
     },
     twitter: {
       card: "summary",
       title: `Stellar Ledger #${formattedSequence}`,
-      description: `View ledger details on Stellar Explorer`,
+      description: `View ledger details on StellarView Explorer`,
     },
   };
 }

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/tx/[hash]/opengraph-image.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/tx/[hash]/opengraph-image.tsx
@@ -122,7 +122,7 @@ export default async function Image({ params }: { params: { hash: string; locale
         </div>
       </div>
 
-      {/* Stellar Explorer branding */}
+      {/* StellarView Explorer branding */}
       <div
         style={{
           position: "absolute",
@@ -154,7 +154,7 @@ export default async function Image({ params }: { params: { hash: string; locale
             <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
           </svg>
         </div>
-        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>Stellar Explorer</span>
+        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>StellarView Explorer</span>
       </div>
 
       {/* Bottom gradient */}

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/tx/[hash]/page.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/tx/[hash]/page.tsx
@@ -20,13 +20,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description: `View details of Stellar transaction ${shortHash}. Explore operations, effects, and raw XDR data.`,
     openGraph: {
       title: `Stellar Transaction ${shortHash}`,
-      description: `View transaction details on Stellar Explorer`,
+      description: `View transaction details on StellarView Explorer`,
       type: "website",
     },
     twitter: {
       card: "summary",
       title: `Stellar Transaction ${shortHash}`,
-      description: `View transaction details on Stellar Explorer`,
+      description: `View transaction details on StellarView Explorer`,
     },
   };
 }

--- a/apps/explorer-web/src/app/[locale]/layout.tsx
+++ b/apps/explorer-web/src/app/[locale]/layout.tsx
@@ -45,8 +45,8 @@ export async function generateMetadata({
     },
     description: description,
     keywords: [
-      "Stellar Explorer",
-      "Stellar View",
+      "StellarView Explorer",
+      "StellarView",
       "Stellar",
       "blockchain explorer",
       "block explorer",
@@ -62,7 +62,7 @@ export async function generateMetadata({
       "crypto explorer",
       "DeFi",
     ],
-    authors: [{ name: "Stellar View" }],
+    authors: [{ name: "StellarView" }],
     icons: {
       icon: "/stellar-explorer.png",
       apple: "/stellar-explorer.png",

--- a/apps/explorer-web/src/app/[locale]/opengraph-image.tsx
+++ b/apps/explorer-web/src/app/[locale]/opengraph-image.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from "next/og";
 
-export const alt = "Stellar Explorer";
+export const alt = "StellarView Explorer";
 export const size = {
   width: 1200,
   height: 630,
@@ -10,7 +10,7 @@ export const contentType = "image/png";
 export default async function Image({ params }: { params: { locale: string } }) {
   const locale = params.locale || "en";
 
-  const title = locale === "es" ? "Explorador Stellar" : "Stellar Explorer";
+  const title = locale === "es" ? "StellarView Explorer" : "StellarView Explorer";
   const subtitle =
     locale === "es"
       ? "Explora la red Stellar en tiempo real"

--- a/apps/explorer-web/src/components/accounts/account-statement.tsx
+++ b/apps/explorer-web/src/components/accounts/account-statement.tsx
@@ -147,7 +147,7 @@ async function exportPDF(
   doc.setFont("helvetica", "bold");
   doc.setFontSize(13);
   doc.setTextColor(10, 10, 10);
-  doc.text("Stellar Explorer", lx + (logoDataUrl ? logoSize + 2 : 0), ly + 6);
+  doc.text("StellarView Explorer", lx + (logoDataUrl ? logoSize + 2 : 0), ly + 6);
 
   doc.setFont("helvetica", "normal");
   doc.setFontSize(8);

--- a/apps/explorer-web/src/components/layout/dock.tsx
+++ b/apps/explorer-web/src/components/layout/dock.tsx
@@ -130,7 +130,7 @@ export function Dock() {
         {/* Logo */}
         <Link href="/" className="mb-6 flex items-center justify-center">
           <div className="size-9 overflow-hidden rounded-xl transition-transform duration-200 hover:scale-105">
-            <Image src="/stellar-explorer.png" alt="Stellar Explorer" width={36} height={36} />
+            <Image src="/stellar-explorer.png" alt="StellarView Explorer" width={36} height={36} />
           </div>
         </Link>
 

--- a/apps/explorer-web/src/components/layout/header.tsx
+++ b/apps/explorer-web/src/components/layout/header.tsx
@@ -41,7 +41,7 @@ export function Header() {
         <Link href="/" className="group flex items-center gap-2.5 font-semibold md:hidden">
           <Image
             src="/stellar-explorer.png"
-            alt="Stellar Explorer"
+            alt="StellarView Explorer"
             width={32}
             height={32}
             className="rounded-lg"

--- a/apps/explorer-web/src/components/layout/mobile-nav.tsx
+++ b/apps/explorer-web/src/components/layout/mobile-nav.tsx
@@ -55,7 +55,7 @@ export function MobileNav() {
           <SheetTitle className="flex items-center gap-3">
             <Image
               src="/stellar-explorer.png"
-              alt="Stellar Explorer"
+              alt="StellarView Explorer"
               width={32}
               height={32}
               className="rounded-lg"

--- a/apps/explorer-web/src/components/layout/sidebar.tsx
+++ b/apps/explorer-web/src/components/layout/sidebar.tsx
@@ -55,7 +55,7 @@ export function Sidebar() {
         <Link href="/" className="group flex items-center gap-3">
           <Image
             src="/stellar-explorer.png"
-            alt="Stellar Explorer"
+            alt="StellarView Explorer"
             width={36}
             height={36}
             className="shrink-0 rounded-lg transition-transform duration-300 group-hover:scale-110"


### PR DESCRIPTION
- Product renamed to **StellarView Explorer** across README, titles, i18n metadata (9 locales), OG images, nav logos, and PDF export
- Brand string set to **StellarView**
- Generic descriptions ("block explorer for the Stellar network") kept as-is
- Display strings only; asset filenames, domains, and env config untouched