### PR TITLE
Fix Prettier formatting in OpenGraph images

### DIFF
--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/account/[id]/opengraph-image.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/account/[id]/opengraph-image.tsx
@@ -154,7 +154,9 @@ export default async function Image({ params }: { params: { id: string; locale: 
             <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
           </svg>
         </div>
-        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>StellarView Explorer</span>
+        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>
+          StellarView Explorer
+        </span>
       </div>
 
       {/* Bottom gradient */}

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/asset/[slug]/opengraph-image.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/asset/[slug]/opengraph-image.tsx
@@ -177,7 +177,9 @@ export default async function Image({ params }: { params: { slug: string; locale
             <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
           </svg>
         </div>
-        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>StellarView Explorer</span>
+        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>
+          StellarView Explorer
+        </span>
       </div>
 
       {/* Bottom gradient */}

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/contract/[id]/opengraph-image.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/contract/[id]/opengraph-image.tsx
@@ -154,7 +154,9 @@ export default async function Image({ params }: { params: { id: string; locale: 
             <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
           </svg>
         </div>
-        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>StellarView Explorer</span>
+        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>
+          StellarView Explorer
+        </span>
       </div>
 
       {/* Bottom gradient */}

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/ledger/[sequence]/opengraph-image.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/ledger/[sequence]/opengraph-image.tsx
@@ -157,7 +157,9 @@ export default async function Image({ params }: { params: { sequence: string; lo
             <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
           </svg>
         </div>
-        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>StellarView Explorer</span>
+        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>
+          StellarView Explorer
+        </span>
       </div>
 
       {/* Bottom gradient */}

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/tx/[hash]/opengraph-image.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/tx/[hash]/opengraph-image.tsx
@@ -154,7 +154,9 @@ export default async function Image({ params }: { params: { hash: string; locale
             <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
           </svg>
         </div>
-        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>StellarView Explorer</span>
+        <span style={{ color: "rgba(255, 255, 255, 0.5)", fontSize: 18 }}>
+          StellarView Explorer
+        </span>
       </div>
 
       {/* Bottom gradient */}


### PR DESCRIPTION
- Wraps the branding `<span>` in the 5 OpenGraph image routes so lines stay within the 100-char Prettier limit
- Fixes the failing `format:check` step in Frontend CI introduced by the longer StellarView brand string