### PR TITLE
Run Frontend CI on all PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,8 @@ name: Frontend CI
 on:
   push:
     branches: [ main, develop ]
-    paths:
-      - "apps/explorer-web/**"
-      - "package.json"
-      - "bun.lock"
-      - ".github/workflows/ci.yml"
   pull_request:
     branches: [ main, develop ]
-    paths:
-      - "apps/explorer-web/**"
-      - "package.json"
-      - "bun.lock"
-      - ".github/workflows/ci.yml"
 
 jobs:
   ci:


### PR DESCRIPTION
- Removes `paths` filters so Frontend CI runs on every PR to main
- Required so the CI check can gate merges via branch protection without stuck PRs