### PR TITLE
fix(explorer-web): read Umami website ID from env var, remove hardcod…

### DIFF
--- a/apps/explorer-web/.env.local.example
+++ b/apps/explorer-web/.env.local.example
@@ -13,3 +13,6 @@ NEXT_PUBLIC_RPC_URL=https://soroban-rpc.mainnet.stellar.gateway.fm
 
 # Public app URL (used for absolute links in Copy for AI, exports, etc.)
 NEXT_PUBLIC_APP_URL=https://stellarview.acachete.xyz
+
+# Umami analytics website ID (optional — when unset, Umami script is not injected)
+NEXT_PUBLIC_UMAMI_WEBSITE_ID=

--- a/apps/explorer-web/src/app/[locale]/layout.tsx
+++ b/apps/explorer-web/src/app/[locale]/layout.tsx
@@ -111,12 +111,14 @@ export default async function LocaleLayout({
           <Providers>{children}</Providers>
         </NextIntlClientProvider>
         <Analytics />
-        <Script
-          defer
-          src="https://cloud.umami.is/script.js"
-          data-website-id="381d4776-b0ac-43c4-a5d2-eacb5d0beb9b"
-          strategy="afterInteractive"
-        />
+        {process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID ? (
+          <Script
+            defer
+            src="https://cloud.umami.is/script.js"
+            data-website-id={process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID}
+            strategy="afterInteractive"
+          />
+        ) : null}
       </body>
     </html>
   );


### PR DESCRIPTION
fix(explorer-web): read Umami website ID from env var, remove hardcoded value

## Problem

`apps/explorer-web/src/app/[locale]/layout.tsx` hardcoded the Umami analytics
`data-website-id` (`381d4776-…`). Any fork or self-hosted deployment
consequently reported its analytics to the original owner's Umami dashboard,
with no way for the deployer to opt out or substitute their own ID.

## Solution

- Replace the hardcoded `data-website-id` with `process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID`.
- Wrap the Umami `<Script>` element in a conditional so that when the env var
  is unset (or empty), no script tag is rendered at all — deployments that
  don't configure Umami send zero traffic to cloud.umami.is.
- Document `NEXT_PUBLIC_UMAMI_WEBSITE_ID` in `apps/explorer-web/.env.local.example`
  with a clear comment on its optional nature.

## Files changed

- `apps/explorer-web/src/app/[locale]/layout.tsx` — conditional Script render + env-var-driven id
- `apps/explorer-web/.env.local.example` — added `NEXT_PUBLIC_UMAMI_WEBSITE_ID`

## Acceptance criteria (all met)

- [x] No hardcoded website id remains in source (repo-wide grep for `381d4776` returns 0 hits).
- [x] With `NEXT_PUBLIC_UMAMI_WEBSITE_ID` unset → Umami `<script>` is not present in the rendered HTML.
- [x] With `NEXT_PUBLIC_UMAMI_WEBSITE_ID=<id>` set → the script renders with `data-website-id=<id>`.
- [x] Variable is documented in `.env.local.example`.

## How to test

1. Build/run **without** setting `NEXT_PUBLIC_UMAMI_WEBSITE_ID` → view source;
   no `cloud.umami.is/script.js` tag should be present.
2. Set `NEXT_PUBLIC_UMAMI_WEBSITE_ID=your-id-here` and rebuild → view source;
   the script tag should appear with `data-website-id="your-id-here"`.
   
   closes #41 