### PR TITLE
feat(dex): add trading pairs, pair detail, and liquidity pool analyti…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ services/indexer/bin/
 .DS_Store
 *.pem
 
+# local-only scratch/dev tools (e.g. mock servers for manual QA)
+.scratch/
+apps/*/.scratch/
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/apps/explorer-web/messages/de.json
+++ b/apps/explorer-web/messages/de.json
@@ -10,6 +10,7 @@
     "transactions": "Transaktionen",
     "accounts": "Konten",
     "assets": "Assets",
+    "pairs": "Paare",
     "contracts": "Verträge",
     "analytics": "Analytik",
     "learn": "Lernen",
@@ -50,7 +51,10 @@
     "tryAgain": "Erneut versuchen",
     "clearAll": "Alles löschen",
     "remove": "Entfernen",
-    "watch": "Beobachten"
+    "watch": "Beobachten",
+    "previous": "Zurück",
+    "next": "Weiter",
+    "pageOf": "Seite {page} von {total}"
   },
   "errors": {
     "somethingWentWrong": "Etwas ist schief gelaufen",
@@ -158,6 +162,54 @@
     "supply": "Angebot",
     "price": "Preis"
   },
+  "pairs": {
+    "metaTitle": "Handelspaare | StellarView Explorer",
+    "metaDescription": "Entdecke Handelspaare auf der Stellar-DEX. Sieh Volumen, Liquidität und Preis für jedes Paar.",
+    "title": "Handelspaare",
+    "subtitle": "Entdecke Handelspaare auf der dezentralen Börse von Stellar",
+    "findPair": "Paar Finden",
+    "searchPlaceholder": "Nach Asset-Code suchen (z. B. USDC)",
+    "allPairs": "Alle Paare",
+    "aboutPairs": "Stellar-Handelspaare",
+    "aboutPairsDescription": "Handelspaare entstehen, wenn Assets auf der Stellar-DEX oder über einen Liquiditätspool getauscht werden. Nutze die Suche oder Sortierung oben, um Preis, Volumen und Liquidität zu erkunden.",
+    "notAvailable": {
+      "title": "Handelsdaten sind noch nicht verfügbar",
+      "description": "Paar-Aggregate erscheinen hier, sobald der Indexer den Handelsverlauf verarbeitet hat."
+    }
+  },
+  "pair": {
+    "pairs": "Paare",
+    "subtitle": "Handelspaar auf der Stellar-DEX",
+    "candles": "Preischart",
+    "trades": "Trades",
+    "orderbook": "Orderbuch",
+    "recentTrades": "Letzte Trades",
+    "failedToLoadTrades": "Trades konnten nicht geladen werden",
+    "noTrades": "Noch keine Trades",
+    "noTradesDesc": "Für dieses Paar wurden keine Trades erfasst.",
+    "time": "Zeit",
+    "price": "Preis",
+    "amount": "Menge",
+    "amountOf": "Menge ({code})",
+    "failedToLoadOrderbook": "Orderbuch konnte nicht geladen werden",
+    "emptyOrderbook": "Leeres Orderbuch",
+    "emptyOrderbookDesc": "Keine offenen Orders für dieses Paar.",
+    "bestBid": "Bestes Gebot",
+    "midPrice": "Mittelpreis",
+    "bestAsk": "Bester Briefkurs",
+    "bids": "Gebote",
+    "asks": "Angebote",
+    "spread": "Spread",
+    "resolution": {
+      "1m": "1m",
+      "1h": "1h",
+      "1d": "1T"
+    },
+    "notAvailable": {
+      "title": "Handelsdaten sind noch nicht verfügbar",
+      "description": "Kerzendaten erscheinen hier, sobald der Indexer den Handelsverlauf dieses Paars verarbeitet hat."
+    }
+  },
   "contracts": {
     "metaTitle": "Smart Contracts | StellarView Explorer",
     "metaDescription": "Erkunden Sie Soroban Smart Contracts im Stellar-Netzwerk. Suchen und sehen Sie Vertragsdetails.",
@@ -259,7 +311,8 @@
       "noActivity": "Keine Token-Aktivität",
       "noActivityDesc": "Für diesen Vertrag wurden in den letzten 7 Tagen keine Ereignisse gefunden.",
       "recentEvents": "Karte antippen, um Details zu sehen · {count} aktuelle Ereignisse"
-    }
+    },
+    "underlyingAsset": "Zugrunde Liegender Vermögenswert"
   },
   "watchlist": {
     "title": "Merkliste",
@@ -346,7 +399,8 @@
     "failedToLoadData": "Dateneinträge konnten nicht geladen werden",
     "noDataEntries": "Keine Dateneinträge",
     "noDataEntriesDesc": "Dieses Konto hat keine gespeicherten Schlüssel-Wert-Daten.",
-    "dataEntries": "Dateneinträge ({count})"
+    "dataEntries": "Dateneinträge ({count})",
+    "poolShares": "Liquiditätspool-Anteile"
   },
   "operations": {
     "create_account": "Konto erstellen",
@@ -603,7 +657,12 @@
     "xlmPurpose1": "Transaktionsgebühren bezahlen (typischerweise 0.00001 XLM pro Operation)",
     "xlmPurpose2": "Mindestkontostände aufrechterhalten (Basisreserve)",
     "xlmPurpose3": "Spam verhindern durch Anforderung kleiner Beträge für Kontoerstellung",
-    "xlmPurpose4": "Brückenwährung für Asset-übergreifende Transaktionen über DEX"
+    "xlmPurpose4": "Brückenwährung für Asset-übergreifende Transaktionen über DEX",
+    "pools": "Pools",
+    "tradingPairs": "Handelspaare",
+    "noPools": "Keine Liquiditätspools",
+    "noPoolsDesc": "Dieser Vermögenswert befindet sich noch in keinem Liquiditätspool.",
+    "failedToLoadPools": "Liquiditätspools konnten nicht geladen werden"
   },
   "assetsMeta": {
     "stellarLumens": "Stellar Lumens",
@@ -657,6 +716,14 @@
       "holders": "Inhaber",
       "auth": "Auth",
       "noAssetsFound": "Keine Assets gefunden"
+    },
+    "pairTable": {
+      "pair": "Paar",
+      "price": "Preis",
+      "change24h": "24-Std.-Änderung",
+      "volume24h": "24-Std.-Volumen",
+      "liquidity": "Liquidität",
+      "noPairsFound": "Keine Paare gefunden"
     },
     "globalSearch": {
       "search": "Suchen",
@@ -1043,6 +1110,23 @@
     "pool": "Pool",
     "failedToLoadTx": "Transaktionen konnten nicht geladen werden",
     "noTransactions": "Keine Transaktionen",
-    "noTransactionsDesc": "Für diesen Liquiditätspool wurden keine Transaktionen gefunden."
+    "noTransactionsDesc": "Für diesen Liquiditätspool wurden keine Transaktionen gefunden.",
+    "depthChart": "Pool-Tiefe",
+    "activity": "Aktivität",
+    "depositType": "Einzahlung",
+    "withdrawType": "Auszahlung",
+    "tradeType": "Handel",
+    "createdType": "Pool Erstellt",
+    "removedType": "Pool Entfernt",
+    "revokedType": "Reserven Widerrufen",
+    "noActivity": "Noch keine Aktivität",
+    "noActivityDesc": "Für diesen Pool wurden keine Einzahlungen, Auszahlungen oder Trades erfasst.",
+    "failedToLoadActivity": "Aktivität konnte nicht geladen werden",
+    "sharesReceived": "Erhaltene Anteile",
+    "sharesRedeemed": "Eingelöste Anteile",
+    "notAvailable": {
+      "title": "Pool-Verlauf ist noch nicht verfügbar",
+      "description": "Die historische Tiefe wird hier angezeigt, sobald der Indexer die Reserven dieses Pools im Zeitverlauf verarbeitet hat."
+    }
   }
 }

--- a/apps/explorer-web/messages/en.json
+++ b/apps/explorer-web/messages/en.json
@@ -10,6 +10,7 @@
     "transactions": "Transactions",
     "accounts": "Accounts",
     "assets": "Assets",
+    "pairs": "Pairs",
     "contracts": "Contracts",
     "analytics": "Analytics",
     "learn": "Learn",
@@ -50,7 +51,10 @@
     "tryAgain": "Try again",
     "clearAll": "Clear All",
     "remove": "Remove",
-    "watch": "Watch"
+    "watch": "Watch",
+    "previous": "Previous",
+    "next": "Next",
+    "pageOf": "Page {page} of {total}"
   },
   "errors": {
     "somethingWentWrong": "Something went wrong",
@@ -158,6 +162,54 @@
     "supply": "Supply",
     "price": "Price"
   },
+  "pairs": {
+    "metaTitle": "Trading Pairs | StellarView Explorer",
+    "metaDescription": "Explore trading pairs on the Stellar DEX. View volume, liquidity, and price for any pair.",
+    "title": "Trading Pairs",
+    "subtitle": "Explore trading pairs on the Stellar decentralized exchange",
+    "findPair": "Find a Pair",
+    "searchPlaceholder": "Search by asset code (e.g., USDC)",
+    "allPairs": "All Pairs",
+    "aboutPairs": "Stellar Trading Pairs",
+    "aboutPairsDescription": "Trading pairs are formed when assets are exchanged on the Stellar DEX or through a liquidity pool. Search or sort the list above to explore price, volume, and liquidity.",
+    "notAvailable": {
+      "title": "Trading data isn't available yet",
+      "description": "Pair aggregates will appear here once the indexer processes trading history."
+    }
+  },
+  "pair": {
+    "pairs": "Pairs",
+    "subtitle": "Trading pair on the Stellar DEX",
+    "candles": "Price Chart",
+    "trades": "Trades",
+    "orderbook": "Orderbook",
+    "recentTrades": "Recent Trades",
+    "failedToLoadTrades": "Failed to load trades",
+    "noTrades": "No trades yet",
+    "noTradesDesc": "No trades have been recorded for this pair.",
+    "time": "Time",
+    "price": "Price",
+    "amount": "Amount",
+    "amountOf": "Amount ({code})",
+    "failedToLoadOrderbook": "Failed to load orderbook",
+    "emptyOrderbook": "Empty orderbook",
+    "emptyOrderbookDesc": "No open orders for this pair.",
+    "bestBid": "Best Bid",
+    "midPrice": "Mid Price",
+    "bestAsk": "Best Ask",
+    "bids": "Bids",
+    "asks": "Asks",
+    "spread": "Spread",
+    "resolution": {
+      "1m": "1m",
+      "1h": "1h",
+      "1d": "1d"
+    },
+    "notAvailable": {
+      "title": "Trading data isn't available yet",
+      "description": "Candle data will appear here once the indexer processes this pair's trading history."
+    }
+  },
   "contracts": {
     "metaTitle": "Smart Contracts | StellarView Explorer",
     "metaDescription": "Explore Soroban smart contracts on the Stellar network. Search and view contract details.",
@@ -259,7 +311,8 @@
       "noActivity": "No token activity",
       "noActivityDesc": "No events found for this contract in the last 7 days.",
       "recentEvents": "Tap any card to flip and see details · {count} recent events"
-    }
+    },
+    "underlyingAsset": "Underlying Asset"
   },
   "watchlist": {
     "title": "Watchlist",
@@ -346,7 +399,8 @@
     "failedToLoadData": "Failed to load data entries",
     "noDataEntries": "No data entries",
     "noDataEntriesDesc": "This account has no key-value data stored.",
-    "dataEntries": "Data Entries ({count})"
+    "dataEntries": "Data Entries ({count})",
+    "poolShares": "Liquidity Pool Shares"
   },
   "operations": {
     "create_account": "Create Account",
@@ -594,6 +648,14 @@
       "auth": "Auth",
       "noAssetsFound": "No assets found"
     },
+    "pairTable": {
+      "pair": "Pair",
+      "price": "Price",
+      "change24h": "24h Change",
+      "volume24h": "24h Volume",
+      "liquidity": "Liquidity",
+      "noPairsFound": "No pairs found"
+    },
     "globalSearch": {
       "search": "Search",
       "keyboardShortcut": "⌘",
@@ -674,7 +736,12 @@
     "xlmPurpose1": "Pay transaction fees (typically 0.00001 XLM per operation)",
     "xlmPurpose2": "Maintain minimum account balances (base reserve)",
     "xlmPurpose3": "Prevent spam by requiring small amounts for account creation",
-    "xlmPurpose4": "Bridge currency for cross-asset transactions via the DEX"
+    "xlmPurpose4": "Bridge currency for cross-asset transactions via the DEX",
+    "pools": "Pools",
+    "tradingPairs": "Trading Pairs",
+    "noPools": "No liquidity pools",
+    "noPoolsDesc": "This asset isn't held in any liquidity pool yet.",
+    "failedToLoadPools": "Failed to load liquidity pools"
   },
   "ledgerDetails": {
     "title": "Ledger",
@@ -1043,6 +1110,23 @@
     "pool": "Pool",
     "failedToLoadTx": "Failed to load transactions",
     "noTransactions": "No transactions",
-    "noTransactionsDesc": "No transactions found for this liquidity pool."
+    "noTransactionsDesc": "No transactions found for this liquidity pool.",
+    "depthChart": "Pool Depth",
+    "activity": "Activity",
+    "depositType": "Deposit",
+    "withdrawType": "Withdraw",
+    "tradeType": "Trade",
+    "createdType": "Pool Created",
+    "removedType": "Pool Removed",
+    "revokedType": "Reserves Revoked",
+    "noActivity": "No activity yet",
+    "noActivityDesc": "No deposits, withdrawals, or trades have been recorded for this pool.",
+    "failedToLoadActivity": "Failed to load activity",
+    "sharesReceived": "Shares received",
+    "sharesRedeemed": "Shares redeemed",
+    "notAvailable": {
+      "title": "Pool history isn't available yet",
+      "description": "Historical depth will appear here once the indexer processes this pool's reserves over time."
+    }
   }
 }

--- a/apps/explorer-web/messages/es.json
+++ b/apps/explorer-web/messages/es.json
@@ -10,6 +10,7 @@
     "transactions": "Transacciones",
     "accounts": "Cuentas",
     "assets": "Activos",
+    "pairs": "Pares",
     "contracts": "Contratos",
     "analytics": "Analíticas",
     "learn": "Aprender",
@@ -50,7 +51,10 @@
     "tryAgain": "Reintentar",
     "clearAll": "Borrar todo",
     "remove": "Eliminar",
-    "watch": "Seguir"
+    "watch": "Seguir",
+    "previous": "Anterior",
+    "next": "Siguiente",
+    "pageOf": "Página {page} de {total}"
   },
   "errors": {
     "somethingWentWrong": "Algo salió mal",
@@ -158,6 +162,54 @@
     "supply": "Suministro",
     "price": "Precio"
   },
+  "pairs": {
+    "metaTitle": "Pares de Trading | StellarView Explorer",
+    "metaDescription": "Explora los pares de trading en el DEX de Stellar. Consulta volumen, liquidez y precio de cualquier par.",
+    "title": "Pares de Trading",
+    "subtitle": "Explora los pares de trading en el exchange descentralizado de Stellar",
+    "findPair": "Buscar un Par",
+    "searchPlaceholder": "Buscar por código de activo (p. ej., USDC)",
+    "allPairs": "Todos los Pares",
+    "aboutPairs": "Pares de Trading en Stellar",
+    "aboutPairsDescription": "Los pares de trading se forman cuando los activos se intercambian en el DEX de Stellar o mediante un pool de liquidez. Busca u ordena la lista de arriba para explorar precio, volumen y liquidez.",
+    "notAvailable": {
+      "title": "Los datos de trading aún no están disponibles",
+      "description": "Los agregados de pares aparecerán aquí una vez que el indexador procese el historial de trading."
+    }
+  },
+  "pair": {
+    "pairs": "Pares",
+    "subtitle": "Par de trading en el DEX de Stellar",
+    "candles": "Gráfico de Precio",
+    "trades": "Operaciones",
+    "orderbook": "Libro de Órdenes",
+    "recentTrades": "Operaciones Recientes",
+    "failedToLoadTrades": "Error al cargar las operaciones",
+    "noTrades": "Aún no hay operaciones",
+    "noTradesDesc": "No se han registrado operaciones para este par.",
+    "time": "Hora",
+    "price": "Precio",
+    "amount": "Cantidad",
+    "amountOf": "Cantidad ({code})",
+    "failedToLoadOrderbook": "Error al cargar el libro de órdenes",
+    "emptyOrderbook": "Libro de órdenes vacío",
+    "emptyOrderbookDesc": "No hay órdenes abiertas para este par.",
+    "bestBid": "Mejor Compra",
+    "midPrice": "Precio Medio",
+    "bestAsk": "Mejor Venta",
+    "bids": "Compras",
+    "asks": "Ventas",
+    "spread": "Spread",
+    "resolution": {
+      "1m": "1m",
+      "1h": "1h",
+      "1d": "1d"
+    },
+    "notAvailable": {
+      "title": "Los datos de trading aún no están disponibles",
+      "description": "Los datos de velas aparecerán aquí una vez que el indexador procese el historial de este par."
+    }
+  },
   "contracts": {
     "metaTitle": "Contratos inteligentes | StellarView Explorer",
     "metaDescription": "Explora contratos inteligentes Soroban en la red Stellar. Busca y ve detalles de contratos.",
@@ -259,7 +311,8 @@
       "noActivity": "Sin actividad de token",
       "noActivityDesc": "No se encontraron eventos para este contrato en los últimos 7 días.",
       "recentEvents": "Toca cualquier tarjeta para ver detalles · {count} eventos recientes"
-    }
+    },
+    "underlyingAsset": "Activo Subyacente"
   },
   "watchlist": {
     "title": "Favoritos",
@@ -346,7 +399,8 @@
     "failedToLoadData": "Error al cargar las entradas de datos",
     "noDataEntries": "Sin entradas de datos",
     "noDataEntriesDesc": "Esta cuenta no tiene datos clave-valor almacenados.",
-    "dataEntries": "Entradas de Datos ({count})"
+    "dataEntries": "Entradas de Datos ({count})",
+    "poolShares": "Participaciones del Pool de Liquidez"
   },
   "operations": {
     "create_account": "Crear cuenta",
@@ -594,6 +648,14 @@
       "auth": "Auth",
       "noAssetsFound": "No se encontraron activos"
     },
+    "pairTable": {
+      "pair": "Par",
+      "price": "Precio",
+      "change24h": "Cambio 24h",
+      "volume24h": "Volumen 24h",
+      "liquidity": "Liquidez",
+      "noPairsFound": "No se encontraron pares"
+    },
     "globalSearch": {
       "search": "Buscar",
       "keyboardShortcut": "⌘",
@@ -674,7 +736,12 @@
     "xlmPurpose1": "Pagar tarifas de transacción (típicamente 0.00001 XLM por operación)",
     "xlmPurpose2": "Mantener balances mínimos de cuenta (reserva base)",
     "xlmPurpose3": "Prevenir spam requiriendo pequeñas cantidades para crear cuentas",
-    "xlmPurpose4": "Moneda puente para transacciones entre activos vía el DEX"
+    "xlmPurpose4": "Moneda puente para transacciones entre activos vía el DEX",
+    "pools": "Pools",
+    "tradingPairs": "Pares de Trading",
+    "noPools": "Sin pools de liquidez",
+    "noPoolsDesc": "Este activo aún no forma parte de ningún pool de liquidez.",
+    "failedToLoadPools": "Error al cargar los pools de liquidez"
   },
   "ledgerDetails": {
     "title": "Libro",
@@ -1043,6 +1110,23 @@
     "pool": "Pool",
     "failedToLoadTx": "Error al cargar las transacciones",
     "noTransactions": "Sin transacciones",
-    "noTransactionsDesc": "No se encontraron transacciones para este pool de liquidez."
+    "noTransactionsDesc": "No se encontraron transacciones para este pool de liquidez.",
+    "depthChart": "Profundidad del Pool",
+    "activity": "Actividad",
+    "depositType": "Depósito",
+    "withdrawType": "Retiro",
+    "tradeType": "Operación",
+    "createdType": "Pool Creado",
+    "removedType": "Pool Eliminado",
+    "revokedType": "Reservas Revocadas",
+    "noActivity": "Sin actividad todavía",
+    "noActivityDesc": "No se han registrado depósitos, retiros ni operaciones para este pool.",
+    "failedToLoadActivity": "Error al cargar la actividad",
+    "sharesReceived": "Participaciones recibidas",
+    "sharesRedeemed": "Participaciones canjeadas",
+    "notAvailable": {
+      "title": "El historial del pool aún no está disponible",
+      "description": "La profundidad histórica aparecerá aquí una vez que el indexador procese las reservas de este pool a lo largo del tiempo."
+    }
   }
 }

--- a/apps/explorer-web/messages/fr.json
+++ b/apps/explorer-web/messages/fr.json
@@ -10,6 +10,7 @@
     "transactions": "Transactions",
     "accounts": "Comptes",
     "assets": "Actifs",
+    "pairs": "Paires",
     "contracts": "Contrats",
     "analytics": "Analytiques",
     "learn": "Apprendre",
@@ -50,7 +51,10 @@
     "tryAgain": "Réessayer",
     "clearAll": "Tout effacer",
     "remove": "Supprimer",
-    "watch": "Suivre"
+    "watch": "Suivre",
+    "previous": "Précédent",
+    "next": "Suivant",
+    "pageOf": "Page {page} sur {total}"
   },
   "errors": {
     "somethingWentWrong": "Une erreur s'est produite",
@@ -158,6 +162,54 @@
     "supply": "Offre",
     "price": "Prix"
   },
+  "pairs": {
+    "metaTitle": "Paires de Trading | StellarView Explorer",
+    "metaDescription": "Explorez les paires de trading sur le DEX de Stellar. Consultez le volume, la liquidité et le prix de chaque paire.",
+    "title": "Paires de Trading",
+    "subtitle": "Explorez les paires de trading sur l'échange décentralisé de Stellar",
+    "findPair": "Trouver une Paire",
+    "searchPlaceholder": "Rechercher par code d'actif (ex. USDC)",
+    "allPairs": "Toutes les Paires",
+    "aboutPairs": "Paires de Trading sur Stellar",
+    "aboutPairsDescription": "Les paires de trading se forment lorsque des actifs sont échangés sur le DEX de Stellar ou via un pool de liquidité. Recherchez ou triez la liste ci-dessus pour explorer le prix, le volume et la liquidité.",
+    "notAvailable": {
+      "title": "Les données de trading ne sont pas encore disponibles",
+      "description": "Les agrégats de paires apparaîtront ici une fois que l'indexeur aura traité l'historique de trading."
+    }
+  },
+  "pair": {
+    "pairs": "Paires",
+    "subtitle": "Paire de trading sur le DEX de Stellar",
+    "candles": "Graphique de Prix",
+    "trades": "Transactions",
+    "orderbook": "Carnet d'Ordres",
+    "recentTrades": "Transactions Récentes",
+    "failedToLoadTrades": "Échec du chargement des transactions",
+    "noTrades": "Pas encore de transactions",
+    "noTradesDesc": "Aucune transaction enregistrée pour cette paire.",
+    "time": "Heure",
+    "price": "Prix",
+    "amount": "Montant",
+    "amountOf": "Montant ({code})",
+    "failedToLoadOrderbook": "Échec du chargement du carnet d'ordres",
+    "emptyOrderbook": "Carnet d'ordres vide",
+    "emptyOrderbookDesc": "Aucun ordre ouvert pour cette paire.",
+    "bestBid": "Meilleure Offre d'Achat",
+    "midPrice": "Prix Moyen",
+    "bestAsk": "Meilleure Offre de Vente",
+    "bids": "Achats",
+    "asks": "Ventes",
+    "spread": "Écart",
+    "resolution": {
+      "1m": "1m",
+      "1h": "1h",
+      "1d": "1j"
+    },
+    "notAvailable": {
+      "title": "Les données de trading ne sont pas encore disponibles",
+      "description": "Les données de chandeliers apparaîtront ici une fois que l'indexeur aura traité l'historique de cette paire."
+    }
+  },
   "contracts": {
     "metaTitle": "Contrats Intelligents | StellarView Explorer",
     "metaDescription": "Explorez les contrats intelligents Soroban sur le réseau Stellar. Recherchez et consultez les détails des contrats.",
@@ -259,7 +311,8 @@
       "noActivity": "Aucune activité de jeton",
       "noActivityDesc": "Aucun événement trouvé pour ce contrat au cours des 7 derniers jours.",
       "recentEvents": "Appuyez sur une carte pour voir les détails · {count} événements récents"
-    }
+    },
+    "underlyingAsset": "Actif Sous-jacent"
   },
   "watchlist": {
     "title": "Favoris",
@@ -346,7 +399,8 @@
     "failedToLoadData": "Échec du chargement des entrées de données",
     "noDataEntries": "Aucune entrée de données",
     "noDataEntriesDesc": "Ce compte n'a pas de données clé-valeur stockées.",
-    "dataEntries": "Entrées de Données ({count})"
+    "dataEntries": "Entrées de Données ({count})",
+    "poolShares": "Parts du Pool de Liquidité"
   },
   "operations": {
     "create_account": "Creer un compte",
@@ -603,7 +657,12 @@
     "xlmPurpose1": "Payer les frais de transaction (généralement 0.00001 XLM par opération)",
     "xlmPurpose2": "Maintenir les soldes minimum du compte (réserve de base)",
     "xlmPurpose3": "Prévenir le spam en exigeant de petits montants pour la création de compte",
-    "xlmPurpose4": "Monnaie pont pour les transactions inter-actifs via le DEX"
+    "xlmPurpose4": "Monnaie pont pour les transactions inter-actifs via le DEX",
+    "pools": "Pools",
+    "tradingPairs": "Paires de Trading",
+    "noPools": "Aucun pool de liquidité",
+    "noPoolsDesc": "Cet actif ne fait partie d'aucun pool de liquidité pour le moment.",
+    "failedToLoadPools": "Échec du chargement des pools de liquidité"
   },
   "assetsMeta": {
     "stellarLumens": "Stellar Lumens",
@@ -657,6 +716,14 @@
       "holders": "Détenteurs",
       "auth": "Auth",
       "noAssetsFound": "Aucun actif trouvé"
+    },
+    "pairTable": {
+      "pair": "Paire",
+      "price": "Prix",
+      "change24h": "Variation 24h",
+      "volume24h": "Volume 24h",
+      "liquidity": "Liquidité",
+      "noPairsFound": "Aucune paire trouvée"
     },
     "globalSearch": {
       "search": "Rechercher",
@@ -1043,6 +1110,23 @@
     "pool": "Pool",
     "failedToLoadTx": "Échec du chargement des transactions",
     "noTransactions": "Aucune transaction",
-    "noTransactionsDesc": "Aucune transaction trouvée pour ce pool de liquidité."
+    "noTransactionsDesc": "Aucune transaction trouvée pour ce pool de liquidité.",
+    "depthChart": "Profondeur du Pool",
+    "activity": "Activité",
+    "depositType": "Dépôt",
+    "withdrawType": "Retrait",
+    "tradeType": "Échange",
+    "createdType": "Pool Créé",
+    "removedType": "Pool Supprimé",
+    "revokedType": "Réserves Révoquées",
+    "noActivity": "Aucune activité pour le moment",
+    "noActivityDesc": "Aucun dépôt, retrait ou échange n'a été enregistré pour ce pool.",
+    "failedToLoadActivity": "Échec du chargement de l'activité",
+    "sharesReceived": "Parts reçues",
+    "sharesRedeemed": "Parts rachetées",
+    "notAvailable": {
+      "title": "L'historique du pool n'est pas encore disponible",
+      "description": "La profondeur historique apparaîtra ici une fois que l'indexeur aura traité les réserves de ce pool au fil du temps."
+    }
   }
 }

--- a/apps/explorer-web/messages/it.json
+++ b/apps/explorer-web/messages/it.json
@@ -10,6 +10,7 @@
     "transactions": "Transazioni",
     "accounts": "Conti",
     "assets": "Risorse",
+    "pairs": "Coppie",
     "contracts": "Contratti",
     "analytics": "Analitica",
     "learn": "Impara",
@@ -50,7 +51,10 @@
     "tryAgain": "Riprova",
     "clearAll": "Cancella tutto",
     "remove": "Rimuovi",
-    "watch": "Monitora"
+    "watch": "Monitora",
+    "previous": "Precedente",
+    "next": "Successivo",
+    "pageOf": "Pagina {page} di {total}"
   },
   "errors": {
     "somethingWentWrong": "Qualcosa è andato storto",
@@ -158,6 +162,54 @@
     "supply": "Offerta",
     "price": "Prezzo"
   },
+  "pairs": {
+    "metaTitle": "Coppie di Trading | StellarView Explorer",
+    "metaDescription": "Esplora le coppie di trading sul DEX di Stellar. Visualizza volume, liquidità e prezzo di qualsiasi coppia.",
+    "title": "Coppie di Trading",
+    "subtitle": "Esplora le coppie di trading sull'exchange decentralizzato di Stellar",
+    "findPair": "Trova una Coppia",
+    "searchPlaceholder": "Cerca per codice asset (es. USDC)",
+    "allPairs": "Tutte le Coppie",
+    "aboutPairs": "Coppie di Trading su Stellar",
+    "aboutPairsDescription": "Le coppie di trading si formano quando gli asset vengono scambiati sul DEX di Stellar o tramite un pool di liquidità. Cerca oppure ordina l'elenco sopra per esplorare prezzo, volume e liquidità.",
+    "notAvailable": {
+      "title": "I dati di trading non sono ancora disponibili",
+      "description": "Gli aggregati delle coppie appariranno qui non appena l'indexer avrà elaborato lo storico di trading."
+    }
+  },
+  "pair": {
+    "pairs": "Coppie",
+    "subtitle": "Coppia di trading sul DEX di Stellar",
+    "candles": "Grafico dei Prezzi",
+    "trades": "Operazioni",
+    "orderbook": "Libro degli Ordini",
+    "recentTrades": "Operazioni Recenti",
+    "failedToLoadTrades": "Impossibile caricare le operazioni",
+    "noTrades": "Ancora nessuna operazione",
+    "noTradesDesc": "Nessuna operazione registrata per questa coppia.",
+    "time": "Ora",
+    "price": "Prezzo",
+    "amount": "Quantità",
+    "amountOf": "Quantità ({code})",
+    "failedToLoadOrderbook": "Impossibile caricare il libro degli ordini",
+    "emptyOrderbook": "Libro degli ordini vuoto",
+    "emptyOrderbookDesc": "Nessun ordine aperto per questa coppia.",
+    "bestBid": "Miglior Offerta in Acquisto",
+    "midPrice": "Prezzo Medio",
+    "bestAsk": "Miglior Offerta in Vendita",
+    "bids": "Acquisti",
+    "asks": "Vendite",
+    "spread": "Spread",
+    "resolution": {
+      "1m": "1m",
+      "1h": "1h",
+      "1d": "1g"
+    },
+    "notAvailable": {
+      "title": "I dati di trading non sono ancora disponibili",
+      "description": "I dati delle candele appariranno qui non appena l'indexer avrà elaborato lo storico di questa coppia."
+    }
+  },
   "contracts": {
     "metaTitle": "Smart Contract | StellarView Explorer",
     "metaDescription": "Esplora gli smart contract Soroban sulla rete Stellar. Cerca e visualizza i dettagli dei contratti.",
@@ -259,7 +311,8 @@
       "noActivity": "Nessuna attività token",
       "noActivityDesc": "Nessun evento trovato per questo contratto negli ultimi 7 giorni.",
       "recentEvents": "Tocca qualsiasi scheda per vedere i dettagli · {count} eventi recenti"
-    }
+    },
+    "underlyingAsset": "Asset Sottostante"
   },
   "watchlist": {
     "title": "Lista di controllo",
@@ -346,7 +399,8 @@
     "failedToLoadData": "Impossibile caricare le voci di dati",
     "noDataEntries": "Nessuna voce di dati",
     "noDataEntriesDesc": "Questo account non ha dati chiave-valore memorizzati.",
-    "dataEntries": "Voci di Dati ({count})"
+    "dataEntries": "Voci di Dati ({count})",
+    "poolShares": "Quote del Pool di Liquidità"
   },
   "operations": {
     "create_account": "Crea conto",
@@ -594,6 +648,14 @@
       "auth": "Auth",
       "noAssetsFound": "Nessuna risorsa trovata"
     },
+    "pairTable": {
+      "pair": "Coppia",
+      "price": "Prezzo",
+      "change24h": "Variazione 24h",
+      "volume24h": "Volume 24h",
+      "liquidity": "Liquidità",
+      "noPairsFound": "Nessuna coppia trovata"
+    },
     "globalSearch": {
       "search": "Cerca",
       "keyboardShortcut": "⌘",
@@ -674,7 +736,12 @@
     "xlmPurpose1": "Pagare le commissioni di transazione (tipicamente 0,00001 XLM per operazione)",
     "xlmPurpose2": "Mantenere i saldi minimi del conto (riserva base)",
     "xlmPurpose3": "Prevenire lo spam richiedendo piccole quantità per la creazione dell'account",
-    "xlmPurpose4": "Valuta ponte per transazioni tra diverse risorse tramite il DEX"
+    "xlmPurpose4": "Valuta ponte per transazioni tra diverse risorse tramite il DEX",
+    "pools": "Pool",
+    "tradingPairs": "Coppie di Trading",
+    "noPools": "Nessun pool di liquidità",
+    "noPoolsDesc": "Questo asset non fa ancora parte di alcun pool di liquidità.",
+    "failedToLoadPools": "Impossibile caricare i pool di liquidità"
   },
   "ledgerDetails": {
     "title": "Registro",
@@ -1043,6 +1110,23 @@
     "pool": "Pool",
     "failedToLoadTx": "Impossibile caricare le transazioni",
     "noTransactions": "Nessuna transazione",
-    "noTransactionsDesc": "Nessuna transazione trovata per questo pool di liquidità."
+    "noTransactionsDesc": "Nessuna transazione trovata per questo pool di liquidità.",
+    "depthChart": "Profondità del Pool",
+    "activity": "Attività",
+    "depositType": "Deposito",
+    "withdrawType": "Prelievo",
+    "tradeType": "Scambio",
+    "createdType": "Pool Creato",
+    "removedType": "Pool Rimosso",
+    "revokedType": "Riserve Revocate",
+    "noActivity": "Nessuna attività ancora",
+    "noActivityDesc": "Non sono stati registrati depositi, prelievi o scambi per questo pool.",
+    "failedToLoadActivity": "Impossibile caricare l'attività",
+    "sharesReceived": "Quote ricevute",
+    "sharesRedeemed": "Quote riscattate",
+    "notAvailable": {
+      "title": "La cronologia del pool non è ancora disponibile",
+      "description": "La profondità storica apparirà qui non appena l'indexer elaborerà le riserve di questo pool nel tempo."
+    }
   }
 }

--- a/apps/explorer-web/messages/ja.json
+++ b/apps/explorer-web/messages/ja.json
@@ -10,6 +10,7 @@
     "transactions": "トランザクション",
     "accounts": "アカウント",
     "assets": "アセット",
+    "pairs": "ペア",
     "contracts": "コントラクト",
     "analytics": "分析",
     "learn": "学ぶ",
@@ -50,7 +51,10 @@
     "tryAgain": "再試行",
     "clearAll": "すべてクリア",
     "remove": "削除",
-    "watch": "フォロー"
+    "watch": "フォロー",
+    "previous": "前へ",
+    "next": "次へ",
+    "pageOf": "{page} / {total} ページ"
   },
   "errors": {
     "somethingWentWrong": "問題が発生しました",
@@ -158,6 +162,54 @@
     "supply": "供給量",
     "price": "価格"
   },
+  "pairs": {
+    "metaTitle": "取引ペア | StellarView Explorer",
+    "metaDescription": "Stellar DEX の取引ペアを閲覧できます。任意のペアの出来高、流動性、価格を確認しましょう。",
+    "title": "取引ペア",
+    "subtitle": "Stellar の分散型取引所の取引ペアを閲覧",
+    "findPair": "ペアを検索",
+    "searchPlaceholder": "アセットコードで検索（例: USDC）",
+    "allPairs": "すべてのペア",
+    "aboutPairs": "Stellar の取引ペア",
+    "aboutPairsDescription": "取引ペアは、Stellar DEX またはリクイディティプールを通じてアセットが交換されると形成されます。上のリストを検索・並べ替えて、価格、出来高、流動性を確認できます。",
+    "notAvailable": {
+      "title": "取引データはまだ利用できません",
+      "description": "インデクサーが取引履歴の処理を完了すると、ペアの集計データがここに表示されます。"
+    }
+  },
+  "pair": {
+    "pairs": "ペア",
+    "subtitle": "Stellar DEX の取引ペア",
+    "candles": "価格チャート",
+    "trades": "取引",
+    "orderbook": "オーダーブック",
+    "recentTrades": "最近の取引",
+    "failedToLoadTrades": "取引の読み込みに失敗しました",
+    "noTrades": "まだ取引はありません",
+    "noTradesDesc": "このペアの取引は記録されていません。",
+    "time": "時刻",
+    "price": "価格",
+    "amount": "数量",
+    "amountOf": "数量（{code}）",
+    "failedToLoadOrderbook": "オーダーブックの読み込みに失敗しました",
+    "emptyOrderbook": "オーダーブックは空です",
+    "emptyOrderbookDesc": "このペアの未決済注文はありません。",
+    "bestBid": "最良買値",
+    "midPrice": "仲値",
+    "bestAsk": "最良売値",
+    "bids": "買い注文",
+    "asks": "売り注文",
+    "spread": "スプレッド",
+    "resolution": {
+      "1m": "1分",
+      "1h": "1時間",
+      "1d": "1日"
+    },
+    "notAvailable": {
+      "title": "取引データはまだ利用できません",
+      "description": "インデクサーがこのペアの取引履歴の処理を完了すると、ローソク足データがここに表示されます。"
+    }
+  },
   "contracts": {
     "metaTitle": "スマートコントラクト | StellarView Explorer",
     "metaDescription": "Stellarネットワーク上のSorobanスマートコントラクトを探索。コントラクトの詳細を検索・表示。",
@@ -259,7 +311,8 @@
       "noActivity": "トークンアクティビティなし",
       "noActivityDesc": "過去 7 日間でこのコントラクトのイベントが見つかりませんでした。",
       "recentEvents": "カードをタップして詳細を確認 · {count} 件の最近のイベント"
-    }
+    },
+    "underlyingAsset": "原資産"
   },
   "watchlist": {
     "title": "ウォッチリスト",
@@ -346,7 +399,8 @@
     "failedToLoadData": "データエントリの読み込みに失敗しました",
     "noDataEntries": "データエントリなし",
     "noDataEntriesDesc": "このアカウントにはキーバリューデータが保存されていません。",
-    "dataEntries": "データエントリ ({count})"
+    "dataEntries": "データエントリ ({count})",
+    "poolShares": "流動性プールシェア"
   },
   "operations": {
     "create_account": "アカウント作成",
@@ -603,7 +657,12 @@
     "xlmPurpose1": "トランザクション手数料の支払い（通常、操作ごとに0.00001 XLM）",
     "xlmPurpose2": "最低アカウント残高の維持（基本リザーブ）",
     "xlmPurpose3": "アカウント作成に少額を要求することでスパムを防止",
-    "xlmPurpose4": "DEXを介したクロスアセット取引のブリッジ通貨"
+    "xlmPurpose4": "DEXを介したクロスアセット取引のブリッジ通貨",
+    "pools": "プール",
+    "tradingPairs": "取引ペア",
+    "noPools": "流動性プールなし",
+    "noPoolsDesc": "このアセットはまだ流動性プールに含まれていません。",
+    "failedToLoadPools": "流動性プールの読み込みに失敗しました"
   },
   "assetsMeta": {
     "stellarLumens": "Stellar Lumens",
@@ -657,6 +716,14 @@
       "holders": "保有者",
       "auth": "認証",
       "noAssetsFound": "アセットが見つかりません"
+    },
+    "pairTable": {
+      "pair": "ペア",
+      "price": "価格",
+      "change24h": "24時間変動",
+      "volume24h": "24時間出来高",
+      "liquidity": "流動性",
+      "noPairsFound": "ペアが見つかりません"
     },
     "globalSearch": {
       "search": "検索",
@@ -1043,6 +1110,23 @@
     "pool": "プール",
     "failedToLoadTx": "トランザクションの読み込みに失敗しました",
     "noTransactions": "トランザクションなし",
-    "noTransactionsDesc": "この流動性プールのトランザクションが見つかりませんでした。"
+    "noTransactionsDesc": "この流動性プールのトランザクションが見つかりませんでした。",
+    "depthChart": "プール深度",
+    "activity": "アクティビティ",
+    "depositType": "入金",
+    "withdrawType": "出金",
+    "tradeType": "取引",
+    "createdType": "プール作成",
+    "removedType": "プール削除",
+    "revokedType": "準備金取り消し",
+    "noActivity": "まだアクティビティがありません",
+    "noActivityDesc": "このプールでは入金、出金、取引が記録されていません。",
+    "failedToLoadActivity": "アクティビティの読み込みに失敗しました",
+    "sharesReceived": "受け取ったシェア",
+    "sharesRedeemed": "償還したシェア",
+    "notAvailable": {
+      "title": "プールの履歴はまだ利用できません",
+      "description": "インデクサーがこのプールの準備金を時系列で処理すると、履歴の深度がここに表示されます。"
+    }
   }
 }

--- a/apps/explorer-web/messages/ko.json
+++ b/apps/explorer-web/messages/ko.json
@@ -10,6 +10,7 @@
     "transactions": "트랜잭션",
     "accounts": "계정",
     "assets": "자산",
+    "pairs": "페어",
     "contracts": "컨트랙트",
     "analytics": "분석",
     "learn": "학습",
@@ -50,7 +51,10 @@
     "tryAgain": "다시 시도",
     "clearAll": "모두 지우기",
     "remove": "삭제",
-    "watch": "관심목록에 추가"
+    "watch": "관심목록에 추가",
+    "previous": "이전",
+    "next": "다음",
+    "pageOf": "{total}페이지 중 {page}페이지"
   },
   "errors": {
     "somethingWentWrong": "문제가 발생했습니다",
@@ -158,6 +162,54 @@
     "supply": "공급량",
     "price": "가격"
   },
+  "pairs": {
+    "metaTitle": "거래 페어 | StellarView Explorer",
+    "metaDescription": "Stellar DEX의 거래 페어를 살펴보세요. 모든 페어의 거래량, 유동성, 가격을 확인할 수 있습니다.",
+    "title": "거래 페어",
+    "subtitle": "Stellar 탈중앙화 거래소의 거래 페어 살펴보기",
+    "findPair": "페어 찾기",
+    "searchPlaceholder": "자산 코드로 검색 (예: USDC)",
+    "allPairs": "전체 페어",
+    "aboutPairs": "Stellar 거래 페어",
+    "aboutPairsDescription": "거래 페어는 자산이 Stellar DEX 또는 유동성 풀을 통해 교환될 때 형성됩니다. 위 목록을 검색하거나 정렬하여 가격, 거래량, 유동성을 확인해 보세요.",
+    "notAvailable": {
+      "title": "거래 데이터를 아직 사용할 수 없습니다",
+      "description": "인덱서가 거래 내역 처리를 완료하면 페어 집계 데이터가 여기에 표시됩니다."
+    }
+  },
+  "pair": {
+    "pairs": "페어",
+    "subtitle": "Stellar DEX의 거래 페어",
+    "candles": "가격 차트",
+    "trades": "거래 내역",
+    "orderbook": "호가창",
+    "recentTrades": "최근 거래",
+    "failedToLoadTrades": "거래 내역을 불러오지 못했습니다",
+    "noTrades": "아직 거래 내역이 없습니다",
+    "noTradesDesc": "이 페어에 기록된 거래가 없습니다.",
+    "time": "시간",
+    "price": "가격",
+    "amount": "수량",
+    "amountOf": "수량 ({code})",
+    "failedToLoadOrderbook": "호가창을 불러오지 못했습니다",
+    "emptyOrderbook": "호가창이 비어 있습니다",
+    "emptyOrderbookDesc": "이 페어에 대한 미체결 주문이 없습니다.",
+    "bestBid": "최우선 매수호가",
+    "midPrice": "중간가",
+    "bestAsk": "최우선 매도호가",
+    "bids": "매수",
+    "asks": "매도",
+    "spread": "스프레드",
+    "resolution": {
+      "1m": "1분",
+      "1h": "1시간",
+      "1d": "1일"
+    },
+    "notAvailable": {
+      "title": "거래 데이터를 아직 사용할 수 없습니다",
+      "description": "인덱서가 이 페어의 거래 내역 처리를 완료하면 캔들 데이터가 여기에 표시됩니다."
+    }
+  },
   "contracts": {
     "metaTitle": "스마트 컨트랙트 | StellarView Explorer",
     "metaDescription": "Stellar 네트워크의 Soroban 스마트 컨트랙트를 탐색하세요. 컨트랙트 세부 정보를 검색하고 확인하세요.",
@@ -259,7 +311,8 @@
       "noActivity": "토큰 활동 없음",
       "noActivityDesc": "최근 7일 동안 이 계약의 이벤트가 없습니다.",
       "recentEvents": "카드를 탭하여 세부 정보 확인 · 최근 {count}개 이벤트"
-    }
+    },
+    "underlyingAsset": "기초 자산"
   },
   "watchlist": {
     "title": "관심목록",
@@ -346,7 +399,8 @@
     "failedToLoadData": "데이터 항목 로드 실패",
     "noDataEntries": "데이터 항목 없음",
     "noDataEntriesDesc": "이 계정에는 저장된 키-값 데이터가 없습니다.",
-    "dataEntries": "데이터 항목 ({count})"
+    "dataEntries": "데이터 항목 ({count})",
+    "poolShares": "유동성 풀 지분"
   },
   "operations": {
     "create_account": "계정 생성",
@@ -594,6 +648,14 @@
       "auth": "인증",
       "noAssetsFound": "자산을 찾을 수 없습니다"
     },
+    "pairTable": {
+      "pair": "페어",
+      "price": "가격",
+      "change24h": "24시간 변동률",
+      "volume24h": "24시간 거래량",
+      "liquidity": "유동성",
+      "noPairsFound": "페어를 찾을 수 없습니다"
+    },
     "globalSearch": {
       "search": "검색",
       "keyboardShortcut": "⌘",
@@ -674,7 +736,12 @@
     "xlmPurpose1": "트랜잭션 수수료 지불 (일반적으로 오퍼레이션당 0.00001 XLM)",
     "xlmPurpose2": "최소 계정 잔액 유지 (기본 준비금)",
     "xlmPurpose3": "계정 생성에 소량 요구하여 스팸 방지",
-    "xlmPurpose4": "DEX를 통한 교차 자산 거래의 브릿지 통화"
+    "xlmPurpose4": "DEX를 통한 교차 자산 거래의 브릿지 통화",
+    "pools": "풀",
+    "tradingPairs": "거래 페어",
+    "noPools": "유동성 풀 없음",
+    "noPoolsDesc": "이 자산은 아직 어떤 유동성 풀에도 포함되어 있지 않습니다.",
+    "failedToLoadPools": "유동성 풀을 불러오지 못했습니다"
   },
   "ledgerDetails": {
     "title": "원장",
@@ -1043,6 +1110,23 @@
     "pool": "풀",
     "failedToLoadTx": "트랜잭션 로드 실패",
     "noTransactions": "트랜잭션 없음",
-    "noTransactionsDesc": "이 유동성 풀에 대한 트랜잭션을 찾을 수 없습니다."
+    "noTransactionsDesc": "이 유동성 풀에 대한 트랜잭션을 찾을 수 없습니다.",
+    "depthChart": "풀 깊이",
+    "activity": "활동",
+    "depositType": "예치",
+    "withdrawType": "출금",
+    "tradeType": "거래",
+    "createdType": "풀 생성됨",
+    "removedType": "풀 제거됨",
+    "revokedType": "준비금 취소됨",
+    "noActivity": "아직 활동 없음",
+    "noActivityDesc": "이 풀에 대해 기록된 예치, 출금 또는 거래가 없습니다.",
+    "failedToLoadActivity": "활동을 불러오지 못했습니다",
+    "sharesReceived": "받은 지분",
+    "sharesRedeemed": "상환된 지분",
+    "notAvailable": {
+      "title": "풀 기록을 아직 사용할 수 없습니다",
+      "description": "인덱서가 이 풀의 준비금을 시간 경과에 따라 처리하면 여기에 과거 깊이가 표시됩니다."
+    }
   }
 }

--- a/apps/explorer-web/messages/pt.json
+++ b/apps/explorer-web/messages/pt.json
@@ -10,6 +10,7 @@
     "transactions": "Transações",
     "accounts": "Contas",
     "assets": "Ativos",
+    "pairs": "Pares",
     "contracts": "Contratos",
     "analytics": "Análises",
     "learn": "Aprender",
@@ -50,7 +51,10 @@
     "tryAgain": "Tentar novamente",
     "clearAll": "Limpar Tudo",
     "remove": "Remover",
-    "watch": "Seguir"
+    "watch": "Seguir",
+    "previous": "Anterior",
+    "next": "Próximo",
+    "pageOf": "Página {page} de {total}"
   },
   "errors": {
     "somethingWentWrong": "Algo deu errado",
@@ -158,6 +162,54 @@
     "supply": "Oferta",
     "price": "Preço"
   },
+  "pairs": {
+    "metaTitle": "Pares de Negociação | StellarView Explorer",
+    "metaDescription": "Explore os pares de negociação na DEX da Stellar. Veja volume, liquidez e preço de qualquer par.",
+    "title": "Pares de Negociação",
+    "subtitle": "Explore os pares de negociação na exchange descentralizada da Stellar",
+    "findPair": "Encontrar um Par",
+    "searchPlaceholder": "Buscar por código do ativo (ex.: USDC)",
+    "allPairs": "Todos os Pares",
+    "aboutPairs": "Pares de Negociação na Stellar",
+    "aboutPairsDescription": "Os pares de negociação são formados quando ativos são trocados na DEX da Stellar ou por meio de um pool de liquidez. Busque ou ordene a lista acima para explorar preço, volume e liquidez.",
+    "notAvailable": {
+      "title": "Os dados de negociação ainda não estão disponíveis",
+      "description": "Os agregados dos pares aparecerão aqui assim que o indexador processar o histórico de negociação."
+    }
+  },
+  "pair": {
+    "pairs": "Pares",
+    "subtitle": "Par de negociação na DEX da Stellar",
+    "candles": "Gráfico de Preço",
+    "trades": "Negociações",
+    "orderbook": "Livro de Ofertas",
+    "recentTrades": "Negociações Recentes",
+    "failedToLoadTrades": "Falha ao carregar negociações",
+    "noTrades": "Ainda sem negociações",
+    "noTradesDesc": "Nenhuma negociação registrada para este par.",
+    "time": "Hora",
+    "price": "Preço",
+    "amount": "Quantidade",
+    "amountOf": "Quantidade ({code})",
+    "failedToLoadOrderbook": "Falha ao carregar o livro de ofertas",
+    "emptyOrderbook": "Livro de ofertas vazio",
+    "emptyOrderbookDesc": "Nenhuma ordem aberta para este par.",
+    "bestBid": "Melhor Compra",
+    "midPrice": "Preço Médio",
+    "bestAsk": "Melhor Venda",
+    "bids": "Compras",
+    "asks": "Vendas",
+    "spread": "Spread",
+    "resolution": {
+      "1m": "1m",
+      "1h": "1h",
+      "1d": "1d"
+    },
+    "notAvailable": {
+      "title": "Os dados de negociação ainda não estão disponíveis",
+      "description": "Os dados de velas aparecerão aqui assim que o indexador processar o histórico deste par."
+    }
+  },
   "contracts": {
     "metaTitle": "Contratos Inteligentes | StellarView Explorer",
     "metaDescription": "Explore contratos inteligentes Soroban na rede Stellar. Busque e veja detalhes de contratos.",
@@ -259,7 +311,8 @@
       "noActivity": "Sem atividade de token",
       "noActivityDesc": "Nenhum evento encontrado para este contrato nos últimos 7 dias.",
       "recentEvents": "Toque em qualquer cartão para ver detalhes · {count} eventos recentes"
-    }
+    },
+    "underlyingAsset": "Ativo Subjacente"
   },
   "watchlist": {
     "title": "Favoritos",
@@ -346,7 +399,8 @@
     "failedToLoadData": "Falha ao carregar entradas de dados",
     "noDataEntries": "Sem entradas de dados",
     "noDataEntriesDesc": "Esta conta não tem dados chave-valor armazenados.",
-    "dataEntries": "Entradas de Dados ({count})"
+    "dataEntries": "Entradas de Dados ({count})",
+    "poolShares": "Cotas do Pool de Liquidez"
   },
   "operations": {
     "create_account": "Criar conta",
@@ -603,7 +657,12 @@
     "xlmPurpose1": "Pagar taxas de transação (tipicamente 0.00001 XLM por operação)",
     "xlmPurpose2": "Manter saldos mínimos de conta (reserva base)",
     "xlmPurpose3": "Prevenir spam exigindo pequenas quantias para criação de conta",
-    "xlmPurpose4": "Moeda ponte para transações entre ativos via DEX"
+    "xlmPurpose4": "Moeda ponte para transações entre ativos via DEX",
+    "pools": "Pools",
+    "tradingPairs": "Pares de Negociação",
+    "noPools": "Nenhum pool de liquidez",
+    "noPoolsDesc": "Este ativo ainda não está em nenhum pool de liquidez.",
+    "failedToLoadPools": "Falha ao carregar os pools de liquidez"
   },
   "assetsMeta": {
     "stellarLumens": "Stellar Lumens",
@@ -657,6 +716,14 @@
       "holders": "Holders",
       "auth": "Auth",
       "noAssetsFound": "Nenhum ativo encontrado"
+    },
+    "pairTable": {
+      "pair": "Par",
+      "price": "Preço",
+      "change24h": "Variação 24h",
+      "volume24h": "Volume 24h",
+      "liquidity": "Liquidez",
+      "noPairsFound": "Nenhum par encontrado"
     },
     "globalSearch": {
       "search": "Buscar",
@@ -1043,6 +1110,23 @@
     "pool": "Pool",
     "failedToLoadTx": "Falha ao carregar transações",
     "noTransactions": "Sem transações",
-    "noTransactionsDesc": "Nenhuma transação encontrada para este pool de liquidez."
+    "noTransactionsDesc": "Nenhuma transação encontrada para este pool de liquidez.",
+    "depthChart": "Profundidade do Pool",
+    "activity": "Atividade",
+    "depositType": "Depósito",
+    "withdrawType": "Saque",
+    "tradeType": "Negociação",
+    "createdType": "Pool Criado",
+    "removedType": "Pool Removido",
+    "revokedType": "Reservas Revogadas",
+    "noActivity": "Nenhuma atividade ainda",
+    "noActivityDesc": "Nenhum depósito, saque ou negociação foi registrado para este pool.",
+    "failedToLoadActivity": "Falha ao carregar a atividade",
+    "sharesReceived": "Cotas recebidas",
+    "sharesRedeemed": "Cotas resgatadas",
+    "notAvailable": {
+      "title": "O histórico do pool ainda não está disponível",
+      "description": "A profundidade histórica aparecerá aqui assim que o indexador processar as reservas deste pool ao longo do tempo."
+    }
   }
 }

--- a/apps/explorer-web/messages/zh.json
+++ b/apps/explorer-web/messages/zh.json
@@ -10,6 +10,7 @@
     "transactions": "交易",
     "accounts": "账户",
     "assets": "资产",
+    "pairs": "交易对",
     "contracts": "合约",
     "analytics": "分析",
     "learn": "学习",
@@ -50,7 +51,10 @@
     "tryAgain": "重试",
     "clearAll": "清除全部",
     "remove": "移除",
-    "watch": "关注"
+    "watch": "关注",
+    "previous": "上一页",
+    "next": "下一页",
+    "pageOf": "第 {page} 页，共 {total} 页"
   },
   "errors": {
     "somethingWentWrong": "出现问题",
@@ -158,6 +162,54 @@
     "supply": "供应量",
     "price": "价格"
   },
+  "pairs": {
+    "metaTitle": "交易对 | StellarView Explorer",
+    "metaDescription": "浏览 Stellar DEX 上的交易对，查看任意交易对的交易量、流动性和价格。",
+    "title": "交易对",
+    "subtitle": "浏览 Stellar 去中心化交易所的交易对",
+    "findPair": "查找交易对",
+    "searchPlaceholder": "按资产代码搜索（例如 USDC）",
+    "allPairs": "所有交易对",
+    "aboutPairs": "Stellar 交易对",
+    "aboutPairsDescription": "当资产在 Stellar DEX 上或通过流动性池进行交换时，就会形成交易对。使用上方的搜索或排序功能来查看价格、交易量和流动性。",
+    "notAvailable": {
+      "title": "交易数据尚不可用",
+      "description": "索引器处理完交易历史后，交易对聚合数据将显示在此处。"
+    }
+  },
+  "pair": {
+    "pairs": "交易对",
+    "subtitle": "Stellar DEX 上的交易对",
+    "candles": "价格图表",
+    "trades": "成交记录",
+    "orderbook": "订单簿",
+    "recentTrades": "最近成交",
+    "failedToLoadTrades": "加载成交记录失败",
+    "noTrades": "暂无成交记录",
+    "noTradesDesc": "该交易对暂无成交记录。",
+    "time": "时间",
+    "price": "价格",
+    "amount": "数量",
+    "amountOf": "数量 ({code})",
+    "failedToLoadOrderbook": "加载订单簿失败",
+    "emptyOrderbook": "订单簿为空",
+    "emptyOrderbookDesc": "该交易对暂无未成交订单。",
+    "bestBid": "最优买价",
+    "midPrice": "中间价",
+    "bestAsk": "最优卖价",
+    "bids": "买单",
+    "asks": "卖单",
+    "spread": "价差",
+    "resolution": {
+      "1m": "1分钟",
+      "1h": "1小时",
+      "1d": "1天"
+    },
+    "notAvailable": {
+      "title": "交易数据尚不可用",
+      "description": "索引器处理完该交易对的交易历史后，K 线数据将显示在此处。"
+    }
+  },
   "contracts": {
     "metaTitle": "智能合约 | StellarView Explorer",
     "metaDescription": "探索 Stellar 网络上的 Soroban 智能合约。搜索和查看合约详情。",
@@ -259,7 +311,8 @@
       "noActivity": "无代币活动",
       "noActivityDesc": "过去 7 天内未找到此合约的事件。",
       "recentEvents": "点击任意卡片查看详情 · {count} 个最近事件"
-    }
+    },
+    "underlyingAsset": "底层资产"
   },
   "watchlist": {
     "title": "关注列表",
@@ -346,7 +399,8 @@
     "failedToLoadData": "加载数据条目失败",
     "noDataEntries": "无数据条目",
     "noDataEntriesDesc": "此账户没有存储的键值数据。",
-    "dataEntries": "数据条目 ({count})"
+    "dataEntries": "数据条目 ({count})",
+    "poolShares": "流动性池份额"
   },
   "operations": {
     "create_account": "创建账户",
@@ -603,7 +657,12 @@
     "xlmPurpose1": "支付交易费用（通常每笔操作 0.00001 XLM）",
     "xlmPurpose2": "维持最低账户余额（基础储备）",
     "xlmPurpose3": "通过要求创建账户时支付少量金额来防止垃圾交易",
-    "xlmPurpose4": "通过 DEX 进行跨资产交易的桥接货币"
+    "xlmPurpose4": "通过 DEX 进行跨资产交易的桥接货币",
+    "pools": "资金池",
+    "tradingPairs": "交易对",
+    "noPools": "暂无流动性池",
+    "noPoolsDesc": "该资产尚未进入任何流动性池。",
+    "failedToLoadPools": "加载流动性池失败"
   },
   "assetsMeta": {
     "stellarLumens": "Stellar Lumens",
@@ -657,6 +716,14 @@
       "holders": "持有者",
       "auth": "授权",
       "noAssetsFound": "未找到资产"
+    },
+    "pairTable": {
+      "pair": "交易对",
+      "price": "价格",
+      "change24h": "24小时涨跌",
+      "volume24h": "24小时交易量",
+      "liquidity": "流动性",
+      "noPairsFound": "未找到交易对"
     },
     "globalSearch": {
       "search": "搜索",
@@ -1043,6 +1110,23 @@
     "pool": "池",
     "failedToLoadTx": "加载交易失败",
     "noTransactions": "无交易",
-    "noTransactionsDesc": "未找到此流动性池的交易记录。"
+    "noTransactionsDesc": "未找到此流动性池的交易记录。",
+    "depthChart": "资金池深度",
+    "activity": "活动",
+    "depositType": "存入",
+    "withdrawType": "提取",
+    "tradeType": "交易",
+    "createdType": "资金池已创建",
+    "removedType": "资金池已移除",
+    "revokedType": "储备已撤销",
+    "noActivity": "暂无活动",
+    "noActivityDesc": "该资金池尚未记录任何存入、提取或交易。",
+    "failedToLoadActivity": "加载活动失败",
+    "sharesReceived": "获得份额",
+    "sharesRedeemed": "赎回份额",
+    "notAvailable": {
+      "title": "资金池历史数据尚不可用",
+      "description": "索引器处理完该资金池的储备历史后，深度数据将显示在此处。"
+    }
   }
 }

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/account/[id]/sections/account-balances.test.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/account/[id]/sections/account-balances.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { AccountBalances } from "./account-balances";
+import type { Horizon } from "@stellar/stellar-sdk";
+
+afterEach(cleanup);
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Link: ({ href, children, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const poolId = "b".repeat(64);
+
+describe("AccountBalances", () => {
+  it("links liquidity pool share balances to the pool detail page", () => {
+    const account = {
+      balances: [
+        {
+          asset_type: "native",
+          balance: "100.0000000",
+          buying_liabilities: "0",
+          selling_liabilities: "0",
+        },
+        {
+          asset_type: "liquidity_pool_shares",
+          liquidity_pool_id: poolId,
+          balance: "42.0000000",
+          limit: "1000",
+          last_modified_ledger: 1,
+          is_authorized: true,
+          is_authorized_to_maintain_liabilities: true,
+          is_clawback_enabled: false,
+        },
+      ],
+    } as unknown as Horizon.ServerApi.AccountRecord;
+
+    render(<AccountBalances account={account} />);
+
+    expect(screen.getByText("poolShares")).toBeInTheDocument();
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", `/liquidity-pool/${poolId}`);
+  });
+});

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/account/[id]/sections/account-balances.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/account/[id]/sections/account-balances.tsx
@@ -2,8 +2,9 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { HashDisplay } from "@/components/common/hash-display";
+import { Link } from "@/i18n/navigation";
 import { formatNumber } from "@/lib/utils";
-import { Coins } from "lucide-react";
+import { Coins, Droplets, ChevronRight } from "lucide-react";
 import type { Horizon } from "@stellar/stellar-sdk";
 import { useTranslations } from "next-intl";
 
@@ -20,6 +21,43 @@ export function AccountBalances({ account }: { account: Horizon.ServerApi.Accoun
       <CardContent>
         <div className="space-y-2">
           {account.balances.map((balance) => {
+            if (balance.asset_type === "liquidity_pool_shares") {
+              const poolBalance = balance as Horizon.HorizonApi.BalanceLineLiquidityPool;
+              return (
+                <Link
+                  key={`liquidity_pool_shares-${poolBalance.liquidity_pool_id}`}
+                  href={`/liquidity-pool/${poolBalance.liquidity_pool_id}`}
+                  className="group block"
+                >
+                  <div className="bg-card/50 hover:bg-muted/50 flex items-center justify-between rounded-lg p-3 transition-colors">
+                    <div className="flex items-center gap-3">
+                      <div className="bg-primary/10 flex size-8 items-center justify-center rounded-md">
+                        <Droplets className="text-primary size-4" />
+                      </div>
+                      <div>
+                        <span className="font-medium">{t("poolShares")}</span>
+                        <div className="text-muted-foreground text-xs">
+                          <HashDisplay
+                            hash={poolBalance.liquidity_pool_id}
+                            truncate
+                            startLength={4}
+                            endLength={4}
+                            copyable={false}
+                          />
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono tabular-nums">
+                        {formatNumber(poolBalance.balance)}
+                      </span>
+                      <ChevronRight className="text-muted-foreground size-4 transition-transform group-hover:translate-x-0.5" />
+                    </div>
+                  </div>
+                </Link>
+              );
+            }
+
             const isNative = balance.asset_type === "native";
             const assetCode = isNative
               ? "XLM"

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/account/[id]/sections/account-offers.test.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/account/[id]/sections/account-offers.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { AccountOffers } from "./account-offers";
+import type { Horizon } from "@stellar/stellar-sdk";
+
+afterEach(cleanup);
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Link: ({ href, children, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const useAccountOffers = vi.fn();
+vi.mock("@/lib/hooks", () => ({
+  useAccountOffers: (...args: unknown[]) => useAccountOffers(...args),
+}));
+
+const USDC_ISSUER = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+
+describe("AccountOffers", () => {
+  it("links each open offer to its trading pair detail page", () => {
+    useAccountOffers.mockReturnValue({
+      data: {
+        records: [
+          {
+            id: "1",
+            selling: { asset_type: "native" },
+            buying: {
+              asset_type: "credit_alphanum4",
+              asset_code: "USDC",
+              asset_issuer: USDC_ISSUER,
+            },
+            amount: "100.0000000",
+            price: "0.11",
+          } as Horizon.ServerApi.OfferRecord,
+        ],
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<AccountOffers accountId="GACCOUNT" />);
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", `/pair/XLM-native_USDC-${USDC_ISSUER}`);
+  });
+
+  it("renders an empty state when there are no open offers", () => {
+    useAccountOffers.mockReturnValue({
+      data: { records: [] },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<AccountOffers accountId="GACCOUNT" />);
+    expect(screen.getByText("noOpenOffers")).toBeInTheDocument();
+  });
+});

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/account/[id]/sections/account-offers.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/account/[id]/sections/account-offers.tsx
@@ -5,11 +5,21 @@ import { Badge } from "@/components/ui/badge";
 import { LoadingCard } from "@/components/common/loading-card";
 import { ErrorState } from "@/components/common/error-state";
 import { EmptyState } from "@/components/common/empty-state";
+import { Link } from "@/i18n/navigation";
 import { useAccountOffers } from "@/lib/hooks";
-import { formatNumber } from "@/lib/utils";
-import { ArrowLeftRight } from "lucide-react";
+import { formatNumber, buildPairSlug } from "@/lib/utils";
+import { ArrowLeftRight, ChevronRight } from "lucide-react";
 import type { Horizon } from "@stellar/stellar-sdk";
 import { useTranslations } from "next-intl";
+
+function offerAsset(asset: { asset_type: string; asset_code?: string; asset_issuer?: string }): {
+  code: string;
+  issuer: string;
+} {
+  return asset.asset_type === "native"
+    ? { code: "XLM", issuer: "native" }
+    : { code: asset.asset_code ?? "", issuer: asset.asset_issuer ?? "" };
+}
 
 export function AccountOffers({ accountId }: { accountId: string }) {
   const { data, isLoading, error, refetch } = useAccountOffers(accountId);
@@ -32,6 +42,8 @@ export function AccountOffers({ accountId }: { accountId: string }) {
       <CardContent>
         <div className="space-y-2">
           {data.records.map((offer: Horizon.ServerApi.OfferRecord) => {
+            const sellingAsset = offerAsset(offer.selling);
+            const buyingAsset = offerAsset(offer.buying);
             const selling =
               offer.selling.asset_type === "native"
                 ? "XLM"
@@ -42,22 +54,28 @@ export function AccountOffers({ accountId }: { accountId: string }) {
                 : `${offer.buying.asset_code}/${offer.buying.asset_issuer?.slice(0, 4)}…`;
 
             return (
-              <div
+              <Link
                 key={offer.id}
-                className="bg-card/50 flex flex-col gap-1.5 rounded-lg p-3 sm:flex-row sm:items-center sm:justify-between"
+                href={`/pair/${buildPairSlug(sellingAsset, buyingAsset)}`}
+                className="group bg-card/50 hover:bg-muted/50 flex flex-col gap-1.5 rounded-lg p-3 transition-colors sm:flex-row sm:items-center sm:justify-between"
               >
                 <div className="flex items-center gap-2 text-sm">
                   <Badge variant="outline">{t("sellAsset", { asset: selling })}</Badge>
                   <span className="text-muted-foreground">→</span>
                   <Badge variant="outline">{t("buyAsset", { asset: buying })}</Badge>
                 </div>
-                <div className="text-muted-foreground text-xs">
-                  {t("amount")}:{" "}
-                  <span className="text-foreground font-medium">{formatNumber(offer.amount)}</span>
-                  {" · "}
-                  {t("price")}: <span className="text-foreground font-medium">{offer.price}</span>
+                <div className="flex items-center gap-2">
+                  <div className="text-muted-foreground text-xs">
+                    {t("amount")}:{" "}
+                    <span className="text-foreground font-medium">
+                      {formatNumber(offer.amount)}
+                    </span>
+                    {" · "}
+                    {t("price")}: <span className="text-foreground font-medium">{offer.price}</span>
+                  </div>
+                  <ChevronRight className="text-muted-foreground size-4 transition-transform group-hover:translate-x-0.5" />
                 </div>
-              </div>
+              </Link>
             );
           })}
         </div>

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/asset/[slug]/asset-content.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/asset/[slug]/asset-content.tsx
@@ -10,7 +10,7 @@ import { LoadingCard } from "@/components/common/loading-card";
 import { ErrorState } from "@/components/common/error-state";
 import { useAsset, useAssetMetadata } from "@/lib/hooks";
 import { parseAssetSlug } from "@/lib/utils";
-import { Lock, Unlock, Building2, BarChart3, BookOpen, Star, Users } from "lucide-react";
+import { Lock, Unlock, Building2, BarChart3, BookOpen, Star, Users, Droplets } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { AssetRecordExtended } from "./sections/types";
 import { AssetSummary } from "./sections/asset-summary";
@@ -20,6 +20,7 @@ import { AssetHolders } from "./sections/asset-holders";
 import { AssetTrades } from "./sections/asset-trades";
 import { AssetOrderbook } from "./sections/asset-orderbook";
 import { AssetMarketData } from "./sections/asset-market-data";
+import { AssetPools } from "./sections/asset-pools";
 
 interface AssetContentProps {
   slug: string;
@@ -163,6 +164,10 @@ export function AssetContent({ slug }: AssetContentProps) {
             <BookOpen className="mr-1.5 size-3.5" />
             Orderbook
           </TabsTrigger>
+          <TabsTrigger value="pools">
+            <Droplets className="mr-1.5 size-3.5" />
+            {t("pools")}
+          </TabsTrigger>
           <TabsTrigger value="market">
             <Star className="mr-1.5 size-3.5" />
             Market
@@ -180,6 +185,9 @@ export function AssetContent({ slug }: AssetContentProps) {
         </TabsContent>
         <TabsContent value="orderbook" className="mt-4">
           <AssetOrderbook code={asset.asset_code} issuer={asset.asset_issuer} />
+        </TabsContent>
+        <TabsContent value="pools" className="mt-4">
+          <AssetPools code={asset.asset_code} issuer={asset.asset_issuer} />
         </TabsContent>
         <TabsContent value="market" className="mt-4">
           <AssetMarketData code={asset.asset_code} issuer={asset.asset_issuer} />

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/asset/[slug]/sections/asset-pools.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/asset/[slug]/sections/asset-pools.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { LoadingCard } from "@/components/common/loading-card";
+import { ErrorState } from "@/components/common/error-state";
+import { EmptyState } from "@/components/common/empty-state";
+import { HashDisplay } from "@/components/common/hash-display";
+import { Link } from "@/i18n/navigation";
+import {
+  PairTable,
+  PairTableSkeleton,
+  PairTableNotAvailable,
+  type PairData,
+} from "@/components/pairs";
+import { useAssetLiquidityPools, useDexPairs } from "@/lib/hooks";
+import { formatNumber } from "@/lib/utils";
+import { Droplets } from "lucide-react";
+import type { Horizon } from "@stellar/stellar-sdk";
+
+interface AssetPoolsProps {
+  code: string;
+  issuer: string;
+}
+
+function reserveLabel(asset: string): string {
+  return asset === "native" ? "XLM" : asset.split(":")[0];
+}
+
+function AssetPoolsList({ code, issuer }: AssetPoolsProps) {
+  const t = useTranslations("assetDetails");
+  const { data, isLoading, error, refetch } = useAssetLiquidityPools(code, issuer);
+
+  if (isLoading) return <LoadingCard rows={3} />;
+  if (error) {
+    return <ErrorState title={t("failedToLoadPools")} message={error.message} onRetry={refetch} />;
+  }
+  if (!data?.records?.length) {
+    return <EmptyState title={t("noPools")} description={t("noPoolsDesc")} />;
+  }
+
+  return (
+    <div className="space-y-2">
+      {data.records.map((pool: Horizon.ServerApi.LiquidityPoolRecord) => (
+        <Link key={pool.id} href={`/liquidity-pool/${pool.id}`} className="group block">
+          <div className="hover:bg-muted/50 flex items-center justify-between gap-3 rounded-lg p-3 transition-colors">
+            <div className="flex items-center gap-2.5">
+              <div className="bg-primary/10 flex size-8 items-center justify-center rounded-md">
+                <Droplets className="text-primary size-4" />
+              </div>
+              <div>
+                <div className="flex items-center gap-1.5">
+                  {pool.reserves.map((r, i) => (
+                    <span key={r.asset} className="flex items-center gap-1.5">
+                      <Badge variant="secondary">{reserveLabel(r.asset)}</Badge>
+                      {i < pool.reserves.length - 1 && (
+                        <span className="text-muted-foreground">/</span>
+                      )}
+                    </span>
+                  ))}
+                </div>
+                <HashDisplay
+                  hash={pool.id}
+                  truncate
+                  startLength={6}
+                  endLength={6}
+                  copyable={false}
+                  className="text-muted-foreground text-xs"
+                />
+              </div>
+            </div>
+            <div className="text-right">
+              {pool.reserves.map((r) => (
+                <p key={r.asset} className="font-mono text-sm tabular-nums">
+                  {formatNumber(r.amount)} {reserveLabel(r.asset)}
+                </p>
+              ))}
+            </div>
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+function AssetPairsList({ code, issuer }: AssetPoolsProps) {
+  const { data: result, isLoading } = useDexPairs();
+
+  const pairs: PairData[] = useMemo(() => {
+    if (!result || !result.available) return [];
+    return result.data.data.filter(
+      (p) =>
+        (p.base.code === code && p.base.issuer === issuer) ||
+        (p.counter.code === code && p.counter.issuer === issuer)
+    );
+  }, [result, code, issuer]);
+
+  if (isLoading) return <PairTableSkeleton rows={3} />;
+  if (!result || !result.available) {
+    return <PairTableNotAvailable />;
+  }
+
+  return <PairTable pairs={pairs} sortKey="volume" sortDir="desc" onSortChange={() => {}} />;
+}
+
+export function AssetPools({ code, issuer }: AssetPoolsProps) {
+  const t = useTranslations("assetDetails");
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">{t("liquidityPools")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <AssetPoolsList code={code} issuer={issuer} />
+        </CardContent>
+      </Card>
+
+      <div className="space-y-2">
+        <h3 className="text-sm font-medium">{t("tradingPairs")}</h3>
+        <AssetPairsList code={code} issuer={issuer} />
+      </div>
+    </div>
+  );
+}

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/contract/[id]/sections/contract-summary.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/contract/[id]/sections/contract-summary.tsx
@@ -3,10 +3,12 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
-import { Hash, Box, Coins } from "lucide-react";
+import { Hash, Box, Coins, ArrowRight } from "lucide-react";
 import { HashDisplay } from "@/components/common/hash-display";
+import { AssetLogo } from "@/components/common/asset-logo";
 import { ContractVerification } from "@/components/contracts";
-import { useContractBalance, useContractCode } from "@/lib/hooks";
+import { Link } from "@/i18n/navigation";
+import { useContractBalance, useContractCode, useContractSacAsset } from "@/lib/hooks";
 import { useTranslations } from "next-intl";
 
 export function ContractSummary({ contractId }: { contractId: string }) {
@@ -14,6 +16,7 @@ export function ContractSummary({ contractId }: { contractId: string }) {
   const { data: balanceData } = useContractBalance(contractId);
   const { data: codeData } = useContractCode(contractId);
   const isSac = codeData?.type === "sac";
+  const { data: sacAsset } = useContractSacAsset(contractId, isSac);
 
   return (
     <Card>
@@ -55,6 +58,22 @@ export function ContractSummary({ contractId }: { contractId: string }) {
               <span className="text-muted-foreground text-sm">{t("status")}</span>
               <Badge className="bg-success/15 text-success border-success/25">{t("active")}</Badge>
             </div>
+            {isSac && sacAsset && (
+              <>
+                <Separator />
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground text-sm">{t("underlyingAsset")}</span>
+                  <Link
+                    href={`/asset/${sacAsset.code}-${sacAsset.issuer}`}
+                    className="hover:text-primary flex items-center gap-1.5 text-sm font-medium transition-colors"
+                  >
+                    <AssetLogo code={sacAsset.code} issuer={sacAsset.issuer} size="sm" />
+                    {sacAsset.code}
+                    <ArrowRight className="size-3.5" />
+                  </Link>
+                </div>
+              </>
+            )}
             {balanceData?.exists && parseFloat(balanceData.balance) > 0 && (
               <>
                 <Separator />

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/liquidity-pool/[id]/liquidity-pool-content.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/liquidity-pool/[id]/liquidity-pool-content.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
@@ -11,10 +12,19 @@ import { ErrorState } from "@/components/common/error-state";
 import { EmptyState } from "@/components/common/empty-state";
 import { TransactionCard, TransactionCardSkeleton } from "@/components/cards/transaction-card";
 import { Breadcrumbs } from "@/components/common/breadcrumbs";
+import {
+  PoolDepthChart,
+  DateRangePicker,
+  CandleResolutionPicker,
+  rangePresetToISO,
+  type DateRangePreset,
+} from "@/components/charts";
+import { PoolActivity } from "./sections/pool-activity";
 import { useLiquidityPool, useLiquidityPoolTransactions } from "@/lib/hooks";
 import { formatNumber, formatCompactNumber, truncateHash } from "@/lib/utils";
-import { Droplets, ArrowLeftRight, Percent } from "lucide-react";
+import { Droplets, ArrowLeftRight, Percent, Activity } from "lucide-react";
 import type { Horizon } from "@stellar/stellar-sdk";
+import type { CandleResolution } from "@/lib/indexer";
 import { useTranslations } from "next-intl";
 
 interface LiquidityPoolContentProps {
@@ -162,6 +172,9 @@ function PoolTransactions({ id }: { id: string }) {
 export function LiquidityPoolContent({ id }: LiquidityPoolContentProps) {
   const { data: pool, isLoading, error, refetch } = useLiquidityPool(id);
   const t = useTranslations("liquidityPool");
+  const [resolution, setResolution] = useState<CandleResolution>("1h");
+  const [range, setRange] = useState<DateRangePreset>("7d");
+  const { from, to } = rangePresetToISO(range);
 
   if (isLoading) {
     return (
@@ -215,10 +228,24 @@ export function LiquidityPoolContent({ id }: LiquidityPoolContentProps) {
 
       <PoolSummary pool={pool} />
 
-      <Tabs defaultValue="transactions" className="w-full">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <CandleResolutionPicker value={resolution} onChange={setResolution} />
+        <DateRangePicker value={range} onChange={setRange} />
+      </div>
+
+      <PoolDepthChart poolId={id} resolution={resolution} from={from} to={to} height={280} />
+
+      <Tabs defaultValue="activity" className="w-full">
         <TabsList>
+          <TabsTrigger value="activity">
+            <Activity className="mr-1.5 size-3.5" />
+            {t("activity")}
+          </TabsTrigger>
           <TabsTrigger value="transactions">{t("transactions")}</TabsTrigger>
         </TabsList>
+        <TabsContent value="activity" className="mt-4">
+          <PoolActivity id={id} />
+        </TabsContent>
         <TabsContent value="transactions" className="mt-4">
           <PoolTransactions id={id} />
         </TabsContent>

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/liquidity-pool/[id]/sections/pool-activity.test.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/liquidity-pool/[id]/sections/pool-activity.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { PoolActivity } from "./pool-activity";
+
+afterEach(cleanup);
+
+vi.mock("@/lib/hooks", () => ({
+  useLiquidityPoolActivity: vi.fn(),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+import { useLiquidityPoolActivity } from "@/lib/hooks";
+
+const poolId = "a".repeat(64);
+
+describe("PoolActivity", () => {
+  it("renders loading state", () => {
+    vi.mocked(useLiquidityPoolActivity).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useLiquidityPoolActivity>);
+
+    render(<PoolActivity id={poolId} />);
+
+    expect(document.querySelector(".animate-pulse")).toBeInTheDocument();
+  });
+
+  it("renders empty state when there is no recorded activity", () => {
+    vi.mocked(useLiquidityPoolActivity).mockReturnValue({
+      data: { records: [] },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useLiquidityPoolActivity>);
+
+    render(<PoolActivity id={poolId} />);
+
+    expect(screen.getByText("noActivity")).toBeInTheDocument();
+  });
+
+  it("renders deposit, withdraw, and trade effects", () => {
+    vi.mocked(useLiquidityPoolActivity).mockReturnValue({
+      data: {
+        records: [
+          {
+            id: "1",
+            type: "liquidity_pool_deposited",
+            created_at: "2024-01-01T00:00:00Z",
+            reserves_deposited: [
+              { asset: "native", amount: "100" },
+              { asset: "USDC:GA5Z", amount: "11" },
+            ],
+            shares_received: "50",
+          },
+          {
+            id: "2",
+            type: "liquidity_pool_withdrew",
+            created_at: "2024-01-01T01:00:00Z",
+            reserves_received: [
+              { asset: "native", amount: "50" },
+              { asset: "USDC:GA5Z", amount: "5.5" },
+            ],
+            shares_redeemed: "25",
+          },
+          {
+            id: "3",
+            type: "liquidity_pool_trade",
+            created_at: "2024-01-01T02:00:00Z",
+            sold: { asset: "native", amount: "10" },
+            bought: { asset: "USDC:GA5Z", amount: "1.1" },
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useLiquidityPoolActivity>);
+
+    render(<PoolActivity id={poolId} />);
+
+    expect(screen.getByText("depositType")).toBeInTheDocument();
+    expect(screen.getByText("withdrawType")).toBeInTheDocument();
+    expect(screen.getByText("tradeType")).toBeInTheDocument();
+  });
+});

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/liquidity-pool/[id]/sections/pool-activity.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/liquidity-pool/[id]/sections/pool-activity.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { LoadingCard } from "@/components/common/loading-card";
+import { ErrorState } from "@/components/common/error-state";
+import { EmptyState } from "@/components/common/empty-state";
+import { formatNumber, formatTimeAgo } from "@/lib/utils";
+import { useLiquidityPoolActivity } from "@/lib/hooks";
+import { ArrowDownToLine, ArrowUpFromLine, ArrowLeftRight, Info } from "lucide-react";
+import type { Horizon } from "@stellar/stellar-sdk";
+
+interface PoolActivityProps {
+  id: string;
+}
+
+function reserveLabel(asset: string): string {
+  return asset === "native" ? "XLM" : asset.split(":")[0];
+}
+
+function reservesText(reserves: Horizon.HorizonApi.Reserve[]): string {
+  return reserves.map((r) => `${formatNumber(r.amount)} ${reserveLabel(r.asset)}`).join(" + ");
+}
+
+function ActivityRow({
+  effect,
+  t,
+}: {
+  effect: Horizon.ServerApi.EffectRecord;
+  t: (key: string) => string;
+}) {
+  if (effect.type === "liquidity_pool_deposited") {
+    return (
+      <div className="flex items-center justify-between gap-3 border-b py-2.5 text-sm last:border-0">
+        <div className="flex items-center gap-2.5">
+          <div className="bg-success/10 flex size-8 items-center justify-center rounded-md">
+            <ArrowDownToLine className="text-success size-4" />
+          </div>
+          <div>
+            <p className="font-medium">{t("depositType")}</p>
+            <p className="text-muted-foreground text-xs">{formatTimeAgo(effect.created_at)}</p>
+          </div>
+        </div>
+        <div className="text-right">
+          <p className="font-mono">{reservesText(effect.reserves_deposited)}</p>
+          <p className="text-muted-foreground text-xs">
+            {t("sharesReceived")}: {formatNumber(effect.shares_received)}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (effect.type === "liquidity_pool_withdrew") {
+    return (
+      <div className="flex items-center justify-between gap-3 border-b py-2.5 text-sm last:border-0">
+        <div className="flex items-center gap-2.5">
+          <div className="bg-destructive/10 flex size-8 items-center justify-center rounded-md">
+            <ArrowUpFromLine className="text-destructive size-4" />
+          </div>
+          <div>
+            <p className="font-medium">{t("withdrawType")}</p>
+            <p className="text-muted-foreground text-xs">{formatTimeAgo(effect.created_at)}</p>
+          </div>
+        </div>
+        <div className="text-right">
+          <p className="font-mono">{reservesText(effect.reserves_received)}</p>
+          <p className="text-muted-foreground text-xs">
+            {t("sharesRedeemed")}: {formatNumber(effect.shares_redeemed)}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (effect.type === "liquidity_pool_trade") {
+    return (
+      <div className="flex items-center justify-between gap-3 border-b py-2.5 text-sm last:border-0">
+        <div className="flex items-center gap-2.5">
+          <div className="bg-primary/10 flex size-8 items-center justify-center rounded-md">
+            <ArrowLeftRight className="text-primary size-4" />
+          </div>
+          <div>
+            <p className="font-medium">{t("tradeType")}</p>
+            <p className="text-muted-foreground text-xs">{formatTimeAgo(effect.created_at)}</p>
+          </div>
+        </div>
+        <div className="text-right font-mono">
+          <span className="text-destructive">
+            -{formatNumber(effect.sold.amount)} {reserveLabel(effect.sold.asset)}
+          </span>
+          <span className="text-muted-foreground mx-1">/</span>
+          <span className="text-success">
+            +{formatNumber(effect.bought.amount)} {reserveLabel(effect.bought.asset)}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  const genericLabel =
+    effect.type === "liquidity_pool_created"
+      ? t("createdType")
+      : effect.type === "liquidity_pool_removed"
+        ? t("removedType")
+        : effect.type === "liquidity_pool_revoked"
+          ? t("revokedType")
+          : effect.type.replace(/_/g, " ");
+
+  return (
+    <div className="flex items-center justify-between gap-3 border-b py-2.5 text-sm last:border-0">
+      <div className="flex items-center gap-2.5">
+        <div className="bg-muted flex size-8 items-center justify-center rounded-md">
+          <Info className="text-muted-foreground size-4" />
+        </div>
+        <p className="font-medium">{genericLabel}</p>
+      </div>
+      <p className="text-muted-foreground text-xs">{formatTimeAgo(effect.created_at)}</p>
+    </div>
+  );
+}
+
+export function PoolActivity({ id }: PoolActivityProps) {
+  const t = useTranslations("liquidityPool");
+  const { data, isLoading, error, refetch } = useLiquidityPoolActivity(id);
+
+  if (isLoading) {
+    return <LoadingCard rows={5} />;
+  }
+
+  if (error) {
+    return (
+      <ErrorState title={t("failedToLoadActivity")} message={error.message} onRetry={refetch} />
+    );
+  }
+
+  // Horizon's liquidity pool effects feed also includes the account_credited/
+  // account_debited effects from the same underlying operations (e.g. a path
+  // payment routed through the pool). Those amounts are already reflected in
+  // the liquidity_pool_trade row, so only surface pool-level effect types here.
+  const poolEffects = (data?.records ?? []).filter((effect) =>
+    effect.type.startsWith("liquidity_pool_")
+  );
+
+  if (!poolEffects.length) {
+    return <EmptyState title={t("noActivity")} description={t("noActivityDesc")} />;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{t("activity")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-0">
+          {poolEffects.map((effect) => (
+            <ActivityRow key={effect.id} effect={effect} t={t} />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/pair/[slug]/page.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/pair/[slug]/page.tsx
@@ -1,0 +1,34 @@
+import { Metadata } from "next";
+import { PairContent } from "./pair-content";
+import { parsePairSlug } from "@/lib/utils";
+
+type Props = {
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const parsed = parsePairSlug(slug);
+
+  if (!parsed) {
+    return { title: "Pair Not Found" };
+  }
+
+  const { base, counter } = parsed;
+  const pairLabel = `${base.code}/${counter.code}`;
+
+  return {
+    title: `${pairLabel} | StellarView Explorer`,
+    description: `View the ${pairLabel} trading pair on Stellar: candlestick chart, recent trades, and order book.`,
+    openGraph: {
+      title: `${pairLabel} — Stellar Trading Pair`,
+      description: `Candlestick chart, recent trades, and order book for ${pairLabel} on Stellar.`,
+      type: "website",
+    },
+  };
+}
+
+export default async function PairPage({ params }: Props) {
+  const { slug } = await params;
+  return <PairContent slug={slug} />;
+}

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/pair/[slug]/pair-content.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/pair/[slug]/pair-content.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import { notFound } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageHeader } from "@/components/layout/page-header";
+import { Breadcrumbs } from "@/components/common/breadcrumbs";
+import { NetworkBadge } from "@/components/common/network-badge";
+import { AssetLogo } from "@/components/common/asset-logo";
+import CandlestickChart from "@/components/charts/candlestick-chart";
+import {
+  DateRangePicker,
+  rangePresetToISO,
+  CandleResolutionPicker,
+  type DateRangePreset,
+} from "@/components/charts";
+import { PairTrades } from "./sections/pair-trades";
+import { PairOrderbook } from "./sections/pair-orderbook";
+import { useNetwork } from "@/lib/providers";
+import { parsePairSlug } from "@/lib/utils";
+import { BarChart3, BookOpen } from "lucide-react";
+import type { CandleResolution } from "@/lib/indexer";
+
+interface PairContentProps {
+  slug: string;
+}
+
+export function PairContent({ slug }: PairContentProps) {
+  const t = useTranslations("pair");
+  const { network } = useNetwork();
+  const [resolution, setResolution] = useState<CandleResolution>("1h");
+  const [range, setRange] = useState<DateRangePreset>("7d");
+
+  const parsed = parsePairSlug(slug);
+  if (!parsed) {
+    return notFound();
+  }
+  const { base, counter } = parsed;
+  const pairLabel = `${base.code} / ${counter.code}`;
+  const { from, to } = rangePresetToISO(range);
+
+  return (
+    <div className="space-y-6">
+      <Breadcrumbs
+        items={[
+          { label: t("pairs"), href: "/pairs" },
+          { label: pairLabel, href: `/pair/${slug}` },
+        ]}
+      />
+
+      <PageHeader
+        title={pairLabel}
+        backHref="/pairs"
+        backLabel={t("pairs")}
+        showCopy={false}
+        badge={<NetworkBadge network={network} />}
+      />
+
+      <div className="flex items-center gap-3">
+        <div className="flex -space-x-2">
+          <AssetLogo code={base.code} issuer={base.issuer} size="lg" />
+          <AssetLogo code={counter.code} issuer={counter.issuer} size="lg" />
+        </div>
+        <div>
+          <p className="text-lg font-semibold">{pairLabel}</p>
+          <p className="text-muted-foreground text-xs">{t("subtitle")}</p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <CandleResolutionPicker value={resolution} onChange={setResolution} />
+        <DateRangePicker value={range} onChange={setRange} />
+      </div>
+
+      <CandlestickChart pairId={slug} resolution={resolution} from={from} to={to} height={320} />
+
+      <Tabs defaultValue="trades" className="w-full">
+        <TabsList>
+          <TabsTrigger value="trades">
+            <BarChart3 className="mr-1.5 size-3.5" />
+            {t("trades")}
+          </TabsTrigger>
+          <TabsTrigger value="orderbook">
+            <BookOpen className="mr-1.5 size-3.5" />
+            {t("orderbook")}
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="trades" className="mt-4">
+          <PairTrades
+            baseCode={base.code}
+            baseIssuer={base.issuer}
+            counterCode={counter.code}
+            counterIssuer={counter.issuer}
+          />
+        </TabsContent>
+        <TabsContent value="orderbook" className="mt-4">
+          <PairOrderbook
+            baseCode={base.code}
+            baseIssuer={base.issuer}
+            counterCode={counter.code}
+            counterIssuer={counter.issuer}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/pair/[slug]/sections/pair-orderbook.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/pair/[slug]/sections/pair-orderbook.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { LoadingCard } from "@/components/common/loading-card";
+import { ErrorState } from "@/components/common/error-state";
+import { EmptyState } from "@/components/common/empty-state";
+import { usePairOrderbook } from "@/lib/hooks";
+import { formatCompactNumber } from "@/lib/utils";
+
+interface PairOrderbookProps {
+  baseCode: string;
+  baseIssuer: string;
+  counterCode: string;
+  counterIssuer: string;
+}
+
+export function PairOrderbook({
+  baseCode,
+  baseIssuer,
+  counterCode,
+  counterIssuer,
+}: PairOrderbookProps) {
+  const t = useTranslations("pair");
+  const { data, isLoading, error, refetch } = usePairOrderbook(
+    baseCode,
+    baseIssuer,
+    counterCode,
+    counterIssuer
+  );
+
+  if (isLoading) return <LoadingCard rows={5} />;
+  if (error) {
+    return (
+      <ErrorState title={t("failedToLoadOrderbook")} message={error.message} onRetry={refetch} />
+    );
+  }
+  if (!data?.bids?.length && !data?.asks?.length) {
+    return <EmptyState title={t("emptyOrderbook")} description={t("emptyOrderbookDesc")} />;
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      {data.midPrice !== null && (
+        <div className="col-span-full grid grid-cols-3 gap-4">
+          <Card>
+            <CardContent className="p-4 text-center">
+              <div className="text-xl font-semibold tabular-nums">
+                {data.bestBid?.toFixed(7) ?? "—"}
+              </div>
+              <div className="text-muted-foreground mt-1 text-xs">{t("bestBid")}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4 text-center">
+              <div className="text-xl font-semibold tabular-nums">
+                {data.midPrice?.toFixed(7) ?? "—"}
+              </div>
+              <div className="text-muted-foreground mt-1 text-xs">{t("midPrice")}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4 text-center">
+              <div className="text-xl font-semibold tabular-nums">
+                {data.bestAsk?.toFixed(7) ?? "—"}
+              </div>
+              <div className="text-muted-foreground mt-1 text-xs">{t("bestAsk")}</div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-success text-base">{t("bids")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-1">
+            <div className="text-muted-foreground grid grid-cols-2 text-xs">
+              <span>{t("price")}</span>
+              <span className="text-right">{t("amount")}</span>
+            </div>
+            {data.bids.map((bid, i) => (
+              <div key={i} className="text-success/90 grid grid-cols-2 text-sm tabular-nums">
+                <span>{parseFloat(bid.price).toFixed(7)}</span>
+                <span className="text-right">{formatCompactNumber(parseFloat(bid.amount))}</span>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-destructive text-base">{t("asks")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-1">
+            <div className="text-muted-foreground grid grid-cols-2 text-xs">
+              <span>{t("price")}</span>
+              <span className="text-right">{t("amount")}</span>
+            </div>
+            {data.asks.map((ask, i) => (
+              <div key={i} className="text-destructive/90 grid grid-cols-2 text-sm tabular-nums">
+                <span>{parseFloat(ask.price).toFixed(7)}</span>
+                <span className="text-right">{formatCompactNumber(parseFloat(ask.amount))}</span>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {data.spread !== null && (
+        <div className="col-span-full">
+          <p className="text-muted-foreground text-center text-sm">
+            {t("spread")}:{" "}
+            <span className="text-foreground font-medium">{data.spread.toFixed(4)}%</span>
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/pair/[slug]/sections/pair-trades.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/pair/[slug]/sections/pair-trades.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { LoadingCard } from "@/components/common/loading-card";
+import { ErrorState } from "@/components/common/error-state";
+import { EmptyState } from "@/components/common/empty-state";
+import { usePairTrades } from "@/lib/hooks";
+import { formatNumber, formatTimeAgo, cn } from "@/lib/utils";
+import type { Horizon } from "@stellar/stellar-sdk";
+
+interface PairTradesProps {
+  baseCode: string;
+  baseIssuer: string;
+  counterCode: string;
+  counterIssuer: string;
+}
+
+export function PairTrades({ baseCode, baseIssuer, counterCode, counterIssuer }: PairTradesProps) {
+  const t = useTranslations("pair");
+  const { data, isLoading, error, refetch } = usePairTrades(
+    baseCode,
+    baseIssuer,
+    counterCode,
+    counterIssuer
+  );
+
+  if (isLoading) return <LoadingCard rows={5} />;
+  if (error) {
+    return <ErrorState title={t("failedToLoadTrades")} message={error.message} onRetry={refetch} />;
+  }
+  if (!data?.records?.length) {
+    return <EmptyState title={t("noTrades")} description={t("noTradesDesc")} />;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{t("recentTrades")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-muted-foreground mb-2 hidden grid-cols-4 gap-2 text-xs font-medium sm:grid">
+          <span>{t("time")}</span>
+          <span className="text-right">{t("price")}</span>
+          <span className="text-right">{t("amountOf", { code: baseCode })}</span>
+          <span className="text-right">{t("amountOf", { code: counterCode })}</span>
+        </div>
+        <div className="space-y-1">
+          {data.records.map((trade: Horizon.ServerApi.TradeRecord) => {
+            const price = trade.price
+              ? parseFloat(trade.price.n) / parseFloat(trade.price.d)
+              : null;
+            const isBuy = !trade.base_is_seller;
+            return (
+              <div
+                key={trade.id}
+                className="grid grid-cols-2 gap-2 border-b py-1.5 text-xs last:border-0 sm:grid-cols-4"
+              >
+                <span className="text-muted-foreground">
+                  {formatTimeAgo(trade.ledger_close_time)}
+                </span>
+                <span
+                  className={cn(
+                    "text-right font-mono",
+                    isBuy ? "text-success" : "text-destructive"
+                  )}
+                >
+                  {price !== null ? formatNumber(price, { maximumFractionDigits: 7 }) : "—"}
+                </span>
+                <span className="text-right font-mono">{formatNumber(trade.base_amount)}</span>
+                <span className="text-right font-mono">{formatNumber(trade.counter_amount)}</span>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/pairs/layout.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/pairs/layout.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "pairs" });
+
+  return {
+    title: t("metaTitle"),
+    description: t("metaDescription"),
+    openGraph: {
+      title: t("metaTitle"),
+      description: t("metaDescription"),
+      type: "website",
+    },
+  };
+}
+
+export default function PairsLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/pairs/loading.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/pairs/loading.tsx
@@ -1,0 +1,11 @@
+import { LoadingCard } from "@/components/common/loading-card";
+import { PairTableSkeleton } from "@/components/pairs";
+
+export default function PairsLoading() {
+  return (
+    <div className="space-y-6">
+      <LoadingCard rows={2} />
+      <PairTableSkeleton rows={10} />
+    </div>
+  );
+}

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/pairs/page.test.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/pairs/page.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import PairsPage from "./page";
+import { DEFAULT_PAGE_SIZE } from "@/lib/constants";
+
+afterEach(cleanup);
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Link: ({ href, children, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// AssetLogo fetches TOML metadata via TanStack Query; stub it out so this
+// test doesn't need a QueryClientProvider.
+vi.mock("@/components/common/asset-logo", () => ({
+  AssetLogo: ({ code }: { code: string }) => <span data-testid="asset-logo">{code}</span>,
+}));
+
+vi.mock("@/lib/providers", () => ({
+  useNetwork: () => ({ network: "testnet" }),
+}));
+
+const useDexPairs = vi.fn();
+vi.mock("@/lib/hooks", () => ({
+  useDexPairs: (...args: unknown[]) => useDexPairs(...args),
+}));
+
+// More than one page's worth, with volume descending by insertion order so
+// the default sort (volume desc) keeps a predictable, easy-to-assert layout.
+const PAIR_COUNT = DEFAULT_PAGE_SIZE + 5;
+const pairs = Array.from({ length: PAIR_COUNT }, (_, i) => ({
+  id: `pair-${i}`,
+  base: { code: `TKN${i}`, issuer: "native" },
+  counter: { code: "XLM", issuer: "native" },
+  lastPrice: 0.1,
+  priceChange24h: 1,
+  volume24h: PAIR_COUNT - i,
+  liquidity: 1000,
+}));
+
+describe("PairsPage pagination", () => {
+  it("splits a pair list larger than one page and navigates between pages", () => {
+    useDexPairs.mockReturnValue({
+      data: { available: true, data: { data: pairs } },
+      isLoading: false,
+    });
+
+    render(<PairsPage />);
+
+    expect(screen.getByText("TKN0")).toBeInTheDocument();
+    expect(screen.getByText(`TKN${DEFAULT_PAGE_SIZE - 1}`)).toBeInTheDocument();
+    expect(screen.queryByText(`TKN${DEFAULT_PAGE_SIZE}`)).not.toBeInTheDocument();
+
+    const previousButton = screen.getByRole("button", { name: "previous" });
+    const nextButton = screen.getByRole("button", { name: "next" });
+    expect(previousButton).toBeDisabled();
+    expect(nextButton).not.toBeDisabled();
+
+    fireEvent.click(nextButton);
+
+    expect(screen.queryByText("TKN0")).not.toBeInTheDocument();
+    expect(screen.getByText(`TKN${PAIR_COUNT - 1}`)).toBeInTheDocument();
+    expect(previousButton).not.toBeDisabled();
+    expect(nextButton).toBeDisabled();
+
+    fireEvent.click(previousButton);
+
+    expect(screen.getByText("TKN0")).toBeInTheDocument();
+    expect(previousButton).toBeDisabled();
+  });
+
+  it("resets to the first page when the search query narrows the results", () => {
+    useDexPairs.mockReturnValue({
+      data: { available: true, data: { data: pairs } },
+      isLoading: false,
+    });
+
+    render(<PairsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "next" }));
+    expect(screen.getByText(`TKN${PAIR_COUNT - 1}`)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("searchPlaceholder"), {
+      target: { value: "TKN0" },
+    });
+
+    expect(screen.getByText("TKN0")).toBeInTheDocument();
+    expect(screen.queryByText(`TKN${PAIR_COUNT - 1}`)).not.toBeInTheDocument();
+  });
+
+  it("shows the not-available empty state when the indexer has no pairs yet", () => {
+    useDexPairs.mockReturnValue({
+      data: { available: false, reason: "empty" },
+      isLoading: false,
+    });
+
+    render(<PairsPage />);
+
+    expect(screen.getByText("notAvailable.title")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "next" })).not.toBeInTheDocument();
+  });
+});

--- a/apps/explorer-web/src/app/[locale]/[network]/(explorer)/pairs/page.tsx
+++ b/apps/explorer-web/src/app/[locale]/[network]/(explorer)/pairs/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/layout/page-header";
+import { NetworkBadge } from "@/components/common/network-badge";
+import {
+  PairTable,
+  PairTableSkeleton,
+  PairTableNotAvailable,
+  type PairData,
+  type PairSortKey,
+  type SortDirection,
+} from "@/components/pairs";
+import { useNetwork } from "@/lib/providers";
+import { useDexPairs } from "@/lib/hooks";
+import { DEFAULT_PAGE_SIZE } from "@/lib/constants";
+import { paginate } from "@/lib/utils";
+import { Search, CandlestickChart } from "lucide-react";
+
+// The indexer's pair list response has no cursor/pagination metadata (see
+// PairsResponse in lib/indexer/dex-types.ts), so we fetch a larger batch once
+// and paginate client-side over the filtered/sorted result.
+const PAIRS_FETCH_LIMIT = 100;
+
+function matchesSearch(pair: PairData, query: string): boolean {
+  if (!query) return true;
+  const q = query.trim().toUpperCase();
+  return pair.base.code.toUpperCase().includes(q) || pair.counter.code.toUpperCase().includes(q);
+}
+
+export default function PairsPage() {
+  const t = useTranslations("pairs");
+  const tCommon = useTranslations("common");
+  const { network } = useNetwork();
+  const { data: result, isLoading } = useDexPairs(PAIRS_FETCH_LIMIT);
+  const [search, setSearch] = useState("");
+  const [sortKey, setSortKey] = useState<PairSortKey>("volume");
+  const [sortDir, setSortDir] = useState<SortDirection>("desc");
+  const [page, setPage] = useState(0);
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    setPage(0);
+  };
+
+  const handleSortChange = (key: PairSortKey) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "desc" ? "asc" : "desc"));
+    } else {
+      setSortKey(key);
+      setSortDir("desc");
+    }
+    setPage(0);
+  };
+
+  const pairs: PairData[] = useMemo(() => {
+    if (!result || !result.available) return [];
+    return result.data.data;
+  }, [result]);
+
+  const visiblePairs = useMemo(() => {
+    const filtered = pairs.filter((p) => matchesSearch(p, search));
+    return [...filtered].sort((a, b) => {
+      const aVal = sortKey === "volume" ? a.volume24h : (a.liquidity ?? -Infinity);
+      const bVal = sortKey === "volume" ? b.volume24h : (b.liquidity ?? -Infinity);
+      return sortDir === "desc" ? bVal - aVal : aVal - bVal;
+    });
+  }, [pairs, search, sortKey, sortDir]);
+
+  const {
+    items: pagedPairs,
+    pageCount,
+    currentPage,
+  } = paginate(visiblePairs, page, DEFAULT_PAGE_SIZE);
+
+  const isAvailable = result?.available === true;
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={t("title")}
+        subtitle={t("subtitle")}
+        backHref="/"
+        backLabel={tCommon("home")}
+        showCopy={false}
+        badge={<NetworkBadge network={network} />}
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">{t("findPair")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="relative">
+            <Search className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+            <Input
+              placeholder={t("searchPlaceholder")}
+              aria-label={t("searchPlaceholder")}
+              value={search}
+              onChange={(e) => handleSearchChange(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {isLoading ? (
+        <PairTableSkeleton rows={10} />
+      ) : !isAvailable ? (
+        <PairTableNotAvailable title={t("allPairs")} />
+      ) : (
+        <div className="space-y-3">
+          <PairTable
+            pairs={pagedPairs}
+            title={t("allPairs")}
+            sortKey={sortKey}
+            sortDir={sortDir}
+            onSortChange={handleSortChange}
+          />
+          {visiblePairs.length > 0 && (
+            <div className="flex items-center justify-between">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+                disabled={currentPage === 0}
+              >
+                {tCommon("previous")}
+              </Button>
+              <span className="text-muted-foreground text-sm">
+                {tCommon("pageOf", { page: currentPage + 1, total: pageCount })}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+                disabled={currentPage >= pageCount - 1}
+              >
+                {tCommon("next")}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+
+      <Card>
+        <CardContent className="py-8">
+          <div className="space-y-4 text-center">
+            <div className="flex justify-center">
+              <div className="bg-chart-3/10 flex size-16 items-center justify-center rounded-2xl">
+                <CandlestickChart className="text-chart-3 size-8" />
+              </div>
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold">{t("aboutPairs")}</h3>
+              <p className="text-muted-foreground mx-auto mt-2 max-w-md">
+                {t("aboutPairsDescription")}
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/explorer-web/src/components/assets/asset-table.tsx
+++ b/apps/explorer-web/src/components/assets/asset-table.tsx
@@ -33,7 +33,7 @@ interface AssetTableProps {
   title?: string;
 }
 
-function PriceChange({ change }: { change: number }) {
+export function PriceChange({ change }: { change: number }) {
   if (change === 0) {
     return (
       <span className="text-muted-foreground flex items-center gap-1 text-sm">

--- a/apps/explorer-web/src/components/charts/candle-resolution-picker.tsx
+++ b/apps/explorer-web/src/components/charts/candle-resolution-picker.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+import type { CandleResolution } from "@/lib/indexer";
+
+const CANDLE_RESOLUTIONS: CandleResolution[] = ["1m", "1h", "1d"];
+
+interface CandleResolutionPickerProps {
+  value: CandleResolution;
+  onChange: (resolution: CandleResolution) => void;
+  className?: string;
+}
+
+/** Resolution picker for indexer-backed candle/depth time series (1m/1h/1d buckets). */
+export function CandleResolutionPicker({
+  value,
+  onChange,
+  className,
+}: CandleResolutionPickerProps) {
+  const t = useTranslations("pair");
+
+  return (
+    <div className={cn("bg-muted/50 flex gap-1 rounded-lg p-1", className)}>
+      {CANDLE_RESOLUTIONS.map((r) => (
+        <button
+          key={r}
+          type="button"
+          onClick={() => onChange(r)}
+          className={cn(
+            "rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+            value === r
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          )}
+        >
+          {t(`resolution.${r}`)}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/explorer-web/src/components/charts/candlestick-chart.test.tsx
+++ b/apps/explorer-web/src/components/charts/candlestick-chart.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import CandlestickChart from "./candlestick-chart";
+
+afterEach(cleanup);
+
+vi.mock("@/lib/hooks", () => ({
+  usePairCandles: vi.fn(),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+import { usePairCandles } from "@/lib/hooks";
+
+describe("CandlestickChart", () => {
+  it("renders loading state", () => {
+    vi.mocked(usePairCandles).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as ReturnType<typeof usePairCandles>);
+
+    render(
+      <CandlestickChart
+        pairId="XLM-native_USDC-GA5Z"
+        resolution="1h"
+        from="2024-01-01"
+        to="2024-01-02"
+      />
+    );
+
+    const skeleton = document.querySelector(".animate-pulse");
+    expect(skeleton).toBeInTheDocument();
+  });
+
+  it("renders not available state when indexer#31 hasn't aggregated candles yet", () => {
+    vi.mocked(usePairCandles).mockReturnValue({
+      data: { available: false, reason: "empty" },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof usePairCandles>);
+
+    render(
+      <CandlestickChart
+        pairId="XLM-native_USDC-GA5Z"
+        resolution="1h"
+        from="2024-01-01"
+        to="2024-01-02"
+      />
+    );
+
+    expect(screen.getByText("notAvailable.title")).toBeInTheDocument();
+  });
+
+  it("renders the chart when candles are available", () => {
+    vi.mocked(usePairCandles).mockReturnValue({
+      data: {
+        available: true,
+        data: {
+          pairId: "XLM-native_USDC-GA5Z",
+          resolution: "1h",
+          from: "2024-01-01",
+          to: "2024-01-02",
+          data: [
+            {
+              timestamp: "2024-01-01T00:00:00Z",
+              open: 0.1,
+              high: 0.12,
+              low: 0.09,
+              close: 0.11,
+              volume: 1000,
+            },
+          ],
+        },
+      },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof usePairCandles>);
+
+    const { container } = render(
+      <CandlestickChart
+        pairId="XLM-native_USDC-GA5Z"
+        resolution="1h"
+        from="2024-01-01"
+        to="2024-01-02"
+      />
+    );
+
+    expect(screen.queryByText("notAvailable.title")).not.toBeInTheDocument();
+    expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
+  });
+});

--- a/apps/explorer-web/src/components/charts/candlestick-chart.tsx
+++ b/apps/explorer-web/src/components/charts/candlestick-chart.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  ComposedChart,
+  Bar,
+  XAxis,
+  YAxis,
+  ResponsiveContainer,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
+import { CandlestickChart as CandlestickIcon } from "lucide-react";
+import { ChartWrapper } from "./chart-wrapper";
+import { NotAvailableState } from "./not-available-state";
+import { chartColors, chartAxisStyle, chartGridStyle } from "./chart-config";
+import { usePairCandles } from "@/lib/hooks";
+import { formatNumber } from "@/lib/utils";
+import { useTranslations } from "next-intl";
+import type { Candle, CandleResolution } from "@/lib/indexer";
+
+interface CandlestickChartProps {
+  pairId: string;
+  resolution: CandleResolution;
+  from: string;
+  to: string;
+  height?: number;
+}
+
+interface CandleDatum extends Candle {
+  range: [number, number];
+}
+
+function formatTimestamp(timestamp: string, resolution: CandleResolution): string {
+  const date = new Date(timestamp);
+  if (resolution === "1m" || resolution === "1h") {
+    return date.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+  }
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+interface CandleShapeProps {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  payload?: CandleDatum;
+}
+
+/**
+ * Renders one OHLC candle. Recharts gives us pixel `y`/`height` for the
+ * `range` dataKey ([low, high]) already mapped through the Y axis scale, so
+ * we derive the open/close pixel positions by interpolating within that
+ * range rather than re-scaling manually.
+ */
+function CandleShape({ x = 0, y = 0, width = 0, height = 0, payload }: CandleShapeProps) {
+  if (!payload) return null;
+  const { open, close, high, low } = payload;
+
+  const wickX = x + width / 2;
+  const bodyWidth = Math.max(width * 0.6, 2);
+  const bodyX = x + (width - bodyWidth) / 2;
+  const isUp = close >= open;
+  const color = isUp ? chartColors.success : chartColors.red;
+
+  if (high === low) {
+    const midY = y + height / 2;
+    return <line x1={x} x2={x + width} y1={midY} y2={midY} stroke={color} strokeWidth={1} />;
+  }
+
+  const pxPerUnit = height / (high - low);
+  const openY = y + (high - open) * pxPerUnit;
+  const closeY = y + (high - close) * pxPerUnit;
+  const bodyY = Math.min(openY, closeY);
+  const bodyHeight = Math.max(Math.abs(closeY - openY), 1);
+
+  return (
+    <g>
+      <line x1={wickX} x2={wickX} y1={y} y2={y + height} stroke={color} strokeWidth={1} />
+      <rect x={bodyX} y={bodyY} width={bodyWidth} height={bodyHeight} fill={color} />
+    </g>
+  );
+}
+
+interface CandleTooltipProps {
+  active?: boolean;
+  payload?: Array<{ payload: CandleDatum }>;
+  resolution: CandleResolution;
+}
+
+function CandleTooltip({ active, payload, resolution }: CandleTooltipProps) {
+  if (!active || !payload?.length) return null;
+  const candle = payload[0].payload;
+  const date = new Date(candle.timestamp);
+  const dateStr = date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+  const timeStr =
+    resolution === "1d"
+      ? ""
+      : date.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+
+  const fmt = (v: number) => formatNumber(v, { maximumFractionDigits: 7 });
+
+  return (
+    <div className="border-border bg-popover rounded-lg border px-3 py-2 shadow-lg">
+      <p className="text-muted-foreground mb-1 text-xs">
+        {dateStr} {timeStr}
+      </p>
+      <div className="grid grid-cols-2 gap-x-3 gap-y-0.5 text-xs">
+        <span className="text-muted-foreground">O</span>
+        <span className="text-foreground text-right font-mono">{fmt(candle.open)}</span>
+        <span className="text-muted-foreground">H</span>
+        <span className="text-foreground text-right font-mono">{fmt(candle.high)}</span>
+        <span className="text-muted-foreground">L</span>
+        <span className="text-foreground text-right font-mono">{fmt(candle.low)}</span>
+        <span className="text-muted-foreground">C</span>
+        <span className="text-foreground text-right font-mono">{fmt(candle.close)}</span>
+      </div>
+    </div>
+  );
+}
+
+export default function CandlestickChart({
+  pairId,
+  resolution,
+  from,
+  to,
+  height = 280,
+}: CandlestickChartProps) {
+  const t = useTranslations("pair");
+  const { data: result, isLoading } = usePairCandles(pairId, resolution, from, to);
+
+  const isAvailable = result?.available === true;
+  const candles: CandleDatum[] = useMemo(() => {
+    if (!result || !result.available) return [];
+    return result.data.data.map((c) => ({ ...c, range: [c.low, c.high] as [number, number] }));
+  }, [result]);
+
+  return (
+    <ChartWrapper title={t("candles")} icon={CandlestickIcon} loading={isLoading}>
+      {!isAvailable && !isLoading ? (
+        <NotAvailableState
+          height={height}
+          title={t("notAvailable.title")}
+          description={t("notAvailable.description")}
+        />
+      ) : (
+        <ResponsiveContainer width="100%" height={height}>
+          <ComposedChart data={candles} margin={{ top: 5, right: 5, left: -20, bottom: 0 }}>
+            <CartesianGrid {...chartGridStyle} />
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={(ts: string) => formatTimestamp(ts, resolution)}
+              {...chartAxisStyle}
+              tickLine={false}
+              axisLine={false}
+              interval="preserveStartEnd"
+              minTickGap={50}
+            />
+            <YAxis
+              {...chartAxisStyle}
+              tickLine={false}
+              axisLine={false}
+              domain={["auto", "auto"]}
+              tickFormatter={(v: number) => formatNumber(v, { maximumFractionDigits: 4 })}
+            />
+            <Tooltip content={<CandleTooltip resolution={resolution} />} />
+            <Bar
+              dataKey="range"
+              shape={(props: CandleShapeProps) => <CandleShape {...props} />}
+              isAnimationActive={false}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      )}
+    </ChartWrapper>
+  );
+}

--- a/apps/explorer-web/src/components/charts/index.ts
+++ b/apps/explorer-web/src/components/charts/index.ts
@@ -9,3 +9,5 @@ export {
   rangePresetToISO,
 } from "./analytics-controls";
 export type { DateRangePreset } from "./analytics-controls";
+export { CandleResolutionPicker } from "./candle-resolution-picker";
+export { PoolDepthChart } from "./pool-depth-chart";

--- a/apps/explorer-web/src/components/charts/not-available-state.tsx
+++ b/apps/explorer-web/src/components/charts/not-available-state.tsx
@@ -8,6 +8,9 @@ interface NotAvailableStateProps {
   /** Height to match the chart area. */
   height?: number;
   className?: string;
+  /** Overrides the default "analytics.notAvailable.*" copy for this call site. */
+  title?: string;
+  description?: string;
 }
 
 /**
@@ -15,7 +18,12 @@ interface NotAvailableStateProps {
  * Used inside chart wrappers to maintain consistent layout while clearly
  * communicating that data will appear once the indexer ships real aggregates.
  */
-export function NotAvailableState({ height = 180, className }: NotAvailableStateProps) {
+export function NotAvailableState({
+  height = 180,
+  className,
+  title,
+  description,
+}: NotAvailableStateProps) {
   const t = useTranslations("analytics");
 
   return (
@@ -31,9 +39,11 @@ export function NotAvailableState({ height = 180, className }: NotAvailableState
         <AlertCircle className="text-muted-foreground size-5" />
       </div>
       <div className="text-center">
-        <p className="text-muted-foreground text-sm font-medium">{t("notAvailable.title")}</p>
+        <p className="text-muted-foreground text-sm font-medium">
+          {title ?? t("notAvailable.title")}
+        </p>
         <p className="text-muted-foreground/70 mt-1 max-w-[240px] text-xs">
-          {t("notAvailable.description")}
+          {description ?? t("notAvailable.description")}
         </p>
       </div>
     </div>

--- a/apps/explorer-web/src/components/charts/pool-depth-chart.test.tsx
+++ b/apps/explorer-web/src/components/charts/pool-depth-chart.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { PoolDepthChart } from "./pool-depth-chart";
+
+afterEach(cleanup);
+
+vi.mock("@/lib/hooks", () => ({
+  usePoolDepth: vi.fn(),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+import { usePoolDepth } from "@/lib/hooks";
+
+const poolId = "a".repeat(64);
+
+describe("PoolDepthChart", () => {
+  it("renders loading state", () => {
+    vi.mocked(usePoolDepth).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as ReturnType<typeof usePoolDepth>);
+
+    render(<PoolDepthChart poolId={poolId} resolution="1h" from="2024-01-01" to="2024-01-02" />);
+
+    const skeleton = document.querySelector(".animate-pulse");
+    expect(skeleton).toBeInTheDocument();
+  });
+
+  it("renders not available state when indexer#31 hasn't aggregated depth yet", () => {
+    vi.mocked(usePoolDepth).mockReturnValue({
+      data: { available: false, reason: "empty" },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof usePoolDepth>);
+
+    render(<PoolDepthChart poolId={poolId} resolution="1h" from="2024-01-01" to="2024-01-02" />);
+
+    expect(screen.getByText("notAvailable.title")).toBeInTheDocument();
+  });
+
+  it("renders the chart when depth history is available", () => {
+    vi.mocked(usePoolDepth).mockReturnValue({
+      data: {
+        available: true,
+        data: {
+          poolId,
+          resolution: "1h",
+          from: "2024-01-01",
+          to: "2024-01-02",
+          data: [
+            {
+              timestamp: "2024-01-01T00:00:00Z",
+              reserves: [
+                { asset: "native", amount: 1_000_000 },
+                { asset: "USDC:GA5Z", amount: 110_000 },
+              ],
+              tvl: 2_000_000,
+            },
+          ],
+        },
+      },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof usePoolDepth>);
+
+    const { container } = render(
+      <PoolDepthChart poolId={poolId} resolution="1h" from="2024-01-01" to="2024-01-02" />
+    );
+
+    expect(screen.queryByText("notAvailable.title")).not.toBeInTheDocument();
+    expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
+  });
+});

--- a/apps/explorer-web/src/components/charts/pool-depth-chart.tsx
+++ b/apps/explorer-web/src/components/charts/pool-depth-chart.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  ResponsiveContainer,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
+import { Waves } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { ChartWrapper } from "./chart-wrapper";
+import { NotAvailableState } from "./not-available-state";
+import { chartColors, chartAxisStyle, chartGridStyle } from "./chart-config";
+import { usePoolDepth } from "@/lib/hooks";
+import { formatCompactNumber } from "@/lib/utils";
+import type { CandleResolution, PoolReserve } from "@/lib/indexer";
+
+interface PoolDepthChartProps {
+  poolId: string;
+  resolution: CandleResolution;
+  from: string;
+  to: string;
+  height?: number;
+}
+
+interface DepthDatum {
+  timestamp: string;
+  tvl: number;
+  reserves: PoolReserve[];
+}
+
+function formatTimestamp(timestamp: string, resolution: CandleResolution): string {
+  const date = new Date(timestamp);
+  if (resolution === "1m" || resolution === "1h") {
+    return date.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+  }
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function reserveLabel(asset: string): string {
+  return asset === "native" ? "XLM" : asset.split(":")[0];
+}
+
+interface DepthTooltipProps {
+  active?: boolean;
+  payload?: Array<{ payload: DepthDatum }>;
+}
+
+function DepthTooltip({ active, payload }: DepthTooltipProps) {
+  if (!active || !payload?.length) return null;
+  const point = payload[0].payload;
+  const date = new Date(point.timestamp);
+  const dateStr = date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  return (
+    <div className="border-border bg-popover rounded-lg border px-3 py-2 shadow-lg">
+      <p className="text-muted-foreground mb-1 text-xs">{dateStr}</p>
+      <div className="space-y-0.5 text-xs">
+        {point.reserves.map((r) => (
+          <div key={r.asset} className="flex items-center justify-between gap-3">
+            <span className="text-muted-foreground">{reserveLabel(r.asset)}</span>
+            <span className="text-foreground font-mono">{formatCompactNumber(r.amount)}</span>
+          </div>
+        ))}
+        <div className="flex items-center justify-between gap-3 pt-0.5 font-medium">
+          <span className="text-muted-foreground">TVL</span>
+          <span className="text-foreground font-mono">{formatCompactNumber(point.tvl)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function PoolDepthChart({
+  poolId,
+  resolution,
+  from,
+  to,
+  height = 280,
+}: PoolDepthChartProps) {
+  const t = useTranslations("liquidityPool");
+  const { data: result, isLoading } = usePoolDepth(poolId, resolution, from, to);
+
+  const isAvailable = result?.available === true;
+  const depth: DepthDatum[] = useMemo(() => {
+    if (!result || !result.available) return [];
+    return result.data.data.map((d) => ({
+      timestamp: d.timestamp,
+      tvl: d.tvl,
+      reserves: d.reserves,
+    }));
+  }, [result]);
+
+  return (
+    <ChartWrapper title={t("depthChart")} icon={Waves} loading={isLoading}>
+      {!isAvailable && !isLoading ? (
+        <NotAvailableState
+          height={height}
+          title={t("notAvailable.title")}
+          description={t("notAvailable.description")}
+        />
+      ) : (
+        <ResponsiveContainer width="100%" height={height}>
+          <AreaChart data={depth} margin={{ top: 5, right: 5, left: -20, bottom: 0 }}>
+            <defs>
+              <linearGradient id="poolDepthFill" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor={chartColors.primary} stopOpacity={0.35} />
+                <stop offset="95%" stopColor={chartColors.primary} stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid {...chartGridStyle} />
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={(ts: string) => formatTimestamp(ts, resolution)}
+              {...chartAxisStyle}
+              tickLine={false}
+              axisLine={false}
+              interval="preserveStartEnd"
+              minTickGap={50}
+            />
+            <YAxis
+              {...chartAxisStyle}
+              tickLine={false}
+              axisLine={false}
+              domain={["auto", "auto"]}
+              tickFormatter={(v: number) => formatCompactNumber(v)}
+            />
+            <Tooltip content={<DepthTooltip />} />
+            <Area
+              type="monotone"
+              dataKey="tvl"
+              stroke={chartColors.primary}
+              strokeWidth={2}
+              fill="url(#poolDepthFill)"
+              isAnimationActive={false}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      )}
+    </ChartWrapper>
+  );
+}

--- a/apps/explorer-web/src/components/layout/dock.tsx
+++ b/apps/explorer-web/src/components/layout/dock.tsx
@@ -10,6 +10,7 @@ import {
   ArrowRightLeft,
   Users,
   Coins,
+  CandlestickChart,
   FileCode,
   BarChart3,
   Star,
@@ -108,6 +109,7 @@ export function Dock() {
     { href: "/transactions", icon: ArrowRightLeft, label: t("transactions") },
     { href: "/accounts", icon: Users, label: t("accounts") },
     { href: "/assets", icon: Coins, label: t("assets") },
+    { href: "/pairs", icon: CandlestickChart, label: t("pairs") },
     { href: "/contracts", icon: FileCode, label: t("contracts") },
     { href: "/analytics", icon: BarChart3, label: t("analytics") },
   ];

--- a/apps/explorer-web/src/components/layout/mobile-nav.tsx
+++ b/apps/explorer-web/src/components/layout/mobile-nav.tsx
@@ -8,6 +8,7 @@ import {
   ArrowRightLeft,
   Users,
   Coins,
+  CandlestickChart,
   FileCode,
   BarChart3,
   Star,
@@ -33,6 +34,7 @@ export function MobileNav() {
     { href: "/transactions", icon: ArrowRightLeft, label: t("transactions") },
     { href: "/accounts", icon: Users, label: t("accounts") },
     { href: "/assets", icon: Coins, label: t("assets") },
+    { href: "/pairs", icon: CandlestickChart, label: t("pairs") },
     { href: "/contracts", icon: FileCode, label: t("contracts") },
     { href: "/analytics", icon: BarChart3, label: t("analytics") },
   ];

--- a/apps/explorer-web/src/components/layout/sidebar.tsx
+++ b/apps/explorer-web/src/components/layout/sidebar.tsx
@@ -8,6 +8,7 @@ import {
   ArrowRightLeft,
   Users,
   Coins,
+  CandlestickChart,
   FileCode,
   BarChart3,
   Star,
@@ -34,6 +35,7 @@ export function Sidebar() {
     { href: "/transactions", icon: ArrowRightLeft, label: t("transactions") },
     { href: "/accounts", icon: Users, label: t("accounts") },
     { href: "/assets", icon: Coins, label: t("assets") },
+    { href: "/pairs", icon: CandlestickChart, label: t("pairs") },
     { href: "/contracts", icon: FileCode, label: t("contracts") },
     { href: "/analytics", icon: BarChart3, label: t("analytics") },
   ];

--- a/apps/explorer-web/src/components/pairs/index.ts
+++ b/apps/explorer-web/src/components/pairs/index.ts
@@ -1,0 +1,1 @@
+export * from "./pair-table";

--- a/apps/explorer-web/src/components/pairs/pair-table.test.tsx
+++ b/apps/explorer-web/src/components/pairs/pair-table.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { PairTable, PairTableNotAvailable, type PairData } from "./pair-table";
+
+afterEach(cleanup);
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Link: ({ href, children, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// AssetLogo fetches TOML metadata via TanStack Query; stub it out so these
+// tests don't need a QueryClientProvider.
+vi.mock("@/components/common/asset-logo", () => ({
+  AssetLogo: ({ code }: { code: string }) => <span data-testid="asset-logo">{code}</span>,
+}));
+
+const USDC_ISSUER = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+const AQUA_ISSUER = "GBNZILSTVQZ4R7IKQDGHYGY2QXL5QOFJYQMXPKWRRM5PAV7Y4M67AQUA";
+
+const pairs: PairData[] = [
+  {
+    id: "1",
+    base: { code: "XLM", issuer: "native" },
+    counter: { code: "USDC", issuer: USDC_ISSUER },
+    lastPrice: 0.11,
+    priceChange24h: 2.5,
+    volume24h: 100_000,
+    liquidity: 500_000,
+  },
+  {
+    id: "2",
+    base: { code: "AQUA", issuer: AQUA_ISSUER },
+    counter: { code: "XLM", issuer: "native" },
+    lastPrice: 0.0004,
+    priceChange24h: -1.2,
+    volume24h: 20_000,
+    liquidity: 80_000,
+  },
+];
+
+describe("PairTable", () => {
+  it("renders each pair as a link to its detail page", () => {
+    render(<PairTable pairs={pairs} sortKey="volume" sortDir="desc" onSortChange={vi.fn()} />);
+
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute("href", `/pair/XLM-native_USDC-${USDC_ISSUER}`);
+    expect(links[1]).toHaveAttribute("href", `/pair/AQUA-${AQUA_ISSUER}_XLM-native`);
+  });
+
+  it("calls onSortChange when a sortable header is clicked", () => {
+    const onSortChange = vi.fn();
+    render(<PairTable pairs={pairs} sortKey="volume" sortDir="desc" onSortChange={onSortChange} />);
+
+    fireEvent.click(screen.getByText("liquidity"));
+    expect(onSortChange).toHaveBeenCalledWith("liquidity");
+  });
+
+  it("renders an empty state when there are no pairs", () => {
+    render(<PairTable pairs={[]} sortKey="volume" sortDir="desc" onSortChange={vi.fn()} />);
+    expect(screen.getByText("noPairsFound")).toBeInTheDocument();
+  });
+
+  it("renders a dash for a low-liquidity pair with no price/liquidity data yet", () => {
+    const lowLiquidityPair: PairData = {
+      id: "3",
+      base: { code: "EMPTY", issuer: USDC_ISSUER },
+      counter: { code: "XLM", issuer: "native" },
+      lastPrice: null,
+      priceChange24h: null,
+      volume24h: 0,
+      liquidity: null,
+    };
+
+    render(
+      <PairTable
+        pairs={[lowLiquidityPair]}
+        sortKey="volume"
+        sortDir="desc"
+        onSortChange={vi.fn()}
+      />
+    );
+
+    // price, priceChange (desktop + mobile), and liquidity each fall back to "-"
+    expect(screen.getAllByText("-")).toHaveLength(4);
+  });
+});
+
+describe("PairTableNotAvailable", () => {
+  it("renders the not-available copy", () => {
+    render(<PairTableNotAvailable />);
+    expect(screen.getByText("notAvailable.title")).toBeInTheDocument();
+  });
+});

--- a/apps/explorer-web/src/components/pairs/pair-table.tsx
+++ b/apps/explorer-web/src/components/pairs/pair-table.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { ArrowDown, ArrowUp } from "lucide-react";
+import { Link } from "@/i18n/navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { AssetLogo } from "@/components/common/asset-logo";
+import { NotAvailableState } from "@/components/charts/not-available-state";
+import { EmptyState } from "@/components/common/empty-state";
+import { PriceChange } from "@/components/assets/asset-table";
+import { formatCompactNumber, formatNumber, buildPairSlug, cn } from "@/lib/utils";
+
+export interface PairAssetData {
+  code: string;
+  issuer: string;
+}
+
+export interface PairData {
+  id: string;
+  base: PairAssetData;
+  counter: PairAssetData;
+  lastPrice: number | null;
+  priceChange24h: number | null;
+  volume24h: number;
+  liquidity: number | null;
+}
+
+export type PairSortKey = "volume" | "liquidity";
+export type SortDirection = "asc" | "desc";
+
+interface PairTableProps {
+  pairs: PairData[];
+  title?: string;
+  sortKey: PairSortKey;
+  sortDir: SortDirection;
+  onSortChange: (key: PairSortKey) => void;
+}
+
+export function PairTableSkeleton({ rows = 6 }: { rows?: number }) {
+  return (
+    <Card role="status" aria-busy="true">
+      <CardHeader>
+        <Skeleton className="h-5 w-32" />
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {Array.from({ length: rows }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4">
+              <Skeleton className="size-10 rounded-full" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-3 w-32" />
+              </div>
+              <Skeleton className="h-4 w-16" />
+              <Skeleton className="h-4 w-20" />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Not-available variant sized like a table (rather than a chart) for when
+ * indexer#31's pair aggregates haven't been populated yet.
+ */
+export function PairTableNotAvailable({ title }: { title?: string }) {
+  const t = useTranslations("pairs");
+  return (
+    <Card>
+      {title && (
+        <CardHeader className="pb-4">
+          <CardTitle className="text-base">{title}</CardTitle>
+        </CardHeader>
+      )}
+      <CardContent className={title ? "pt-0" : ""}>
+        <NotAvailableState
+          height={280}
+          title={t("notAvailable.title")}
+          description={t("notAvailable.description")}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+function SortableHeader({
+  label,
+  active,
+  dir,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  dir: SortDirection;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "hover:text-foreground flex items-center justify-end gap-1 transition-colors",
+        active && "text-foreground"
+      )}
+    >
+      {label}
+      {active &&
+        (dir === "desc" ? <ArrowDown className="size-3" /> : <ArrowUp className="size-3" />)}
+    </button>
+  );
+}
+
+export function PairTable({ pairs, title, sortKey, sortDir, onSortChange }: PairTableProps) {
+  const t = useTranslations("components.pairTable");
+
+  if (!pairs || pairs.length === 0) {
+    return (
+      <Card>
+        {title && (
+          <CardHeader className="pb-4">
+            <CardTitle className="text-base">{title}</CardTitle>
+          </CardHeader>
+        )}
+        <CardContent className={title ? "pt-0" : ""}>
+          <EmptyState title={t("noPairsFound")} />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      {title && (
+        <CardHeader className="pb-4">
+          <CardTitle className="text-base">{title}</CardTitle>
+        </CardHeader>
+      )}
+      <CardContent className={title ? "pt-0" : ""}>
+        <div className="text-muted-foreground mb-3 hidden gap-4 border-b pb-3 text-xs font-medium md:grid md:grid-cols-12">
+          <div className="col-span-4">{t("pair")}</div>
+          <div className="col-span-2 text-right">{t("price")}</div>
+          <div className="col-span-2 text-right">{t("change24h")}</div>
+          <div className="col-span-2 text-right">
+            <SortableHeader
+              label={t("volume24h")}
+              active={sortKey === "volume"}
+              dir={sortDir}
+              onClick={() => onSortChange("volume")}
+            />
+          </div>
+          <div className="col-span-2 text-right">
+            <SortableHeader
+              label={t("liquidity")}
+              active={sortKey === "liquidity"}
+              dir={sortDir}
+              onClick={() => onSortChange("liquidity")}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          {pairs.map((pair) => (
+            <Link
+              key={pair.id}
+              href={`/pair/${buildPairSlug(pair.base, pair.counter)}`}
+              className="group block"
+            >
+              <div className="hover:bg-muted/50 grid grid-cols-2 items-center gap-4 rounded-lg p-3 transition-colors md:grid-cols-12">
+                <div className="flex items-center gap-2 md:col-span-4">
+                  <div className="flex -space-x-2">
+                    <AssetLogo code={pair.base.code} issuer={pair.base.issuer} size="sm" />
+                    <AssetLogo code={pair.counter.code} issuer={pair.counter.issuer} size="sm" />
+                  </div>
+                  <div className="min-w-0">
+                    <span className="font-semibold">
+                      {pair.base.code}
+                      <span className="text-muted-foreground mx-1">/</span>
+                      {pair.counter.code}
+                    </span>
+                  </div>
+                </div>
+
+                <div className="col-span-2 hidden text-right md:block">
+                  {pair.lastPrice !== null ? (
+                    <span className="font-mono text-sm">
+                      {formatNumber(pair.lastPrice, { maximumFractionDigits: 7 })}
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground text-sm">-</span>
+                  )}
+                </div>
+
+                <div className="col-span-2 hidden justify-end md:flex">
+                  {pair.priceChange24h !== null ? (
+                    <PriceChange change={pair.priceChange24h} />
+                  ) : (
+                    <span className="text-muted-foreground text-sm">-</span>
+                  )}
+                </div>
+
+                <div className="col-span-2 text-right">
+                  <span className="font-mono text-sm">
+                    {formatCompactNumber(pair.volume24h)} {pair.counter.code}
+                  </span>
+                </div>
+
+                <div className="col-span-2 hidden text-right md:block">
+                  {pair.liquidity !== null ? (
+                    <span className="font-mono text-sm">
+                      {formatCompactNumber(pair.liquidity)} {pair.counter.code}
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground text-sm">-</span>
+                  )}
+                </div>
+
+                <div className="flex justify-end md:hidden">
+                  {pair.priceChange24h !== null ? (
+                    <PriceChange change={pair.priceChange24h} />
+                  ) : (
+                    <span className="text-muted-foreground text-sm">-</span>
+                  )}
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/explorer-web/src/lib/hooks/use-stellar-query.ts
+++ b/apps/explorer-web/src/lib/hooks/use-stellar-query.ts
@@ -169,6 +169,17 @@ export function useContractCode(contractId: string) {
   });
 }
 
+// Hook to resolve a Stellar Asset Contract to the classic asset it wraps.
+// Callers should pass `enabled: isSac` (from useContractCode) since this
+// performs an RPC simulation call.
+export function useContractSacAsset(contractId: string, enabled = true) {
+  const { network } = useNetwork();
+  return useQuery({
+    ...stellarQueries.contractSacAsset(network, contractId),
+    enabled: enabled && !!contractId && contractId.startsWith("C") && contractId.length === 56,
+  });
+}
+
 // Hook for contract storage
 export function useContractStorage(contractId: string) {
   const { network } = useNetwork();
@@ -271,6 +282,15 @@ export function useLiquidityPoolTransactions(id: string) {
   });
 }
 
+// Hook for deposit/withdraw/trade activity in a liquidity pool (Horizon effects)
+export function useLiquidityPoolActivity(id: string) {
+  const { network } = useNetwork();
+  return useQuery({
+    ...stellarQueries.liquidityPoolActivity(network, id),
+    enabled: !!id && id.length === 64,
+  });
+}
+
 // Hook for claimable balances (optionally filtered by asset)
 export function useClaimableBalances(assetCode?: string, assetIssuer?: string, cursor?: string) {
   const { network } = useNetwork();
@@ -348,5 +368,69 @@ export function useIndexerTopN(
   return useQuery({
     ...stellarQueries.indexerTopN(network, metric, window, limit),
     enabled,
+  });
+}
+
+// Hook for the DEX trading pair list (indexer#31, provisional contract)
+export function useDexPairs(limit = 50) {
+  const { network } = useNetwork();
+  return useQuery(stellarQueries.dexPairsList(network, limit));
+}
+
+// Hook for OHLC candles of a trading pair (indexer#31, provisional contract)
+export function usePairCandles(
+  pairId: string,
+  resolution: import("@/lib/indexer").CandleResolution,
+  from: string,
+  to: string,
+  enabled = true
+) {
+  const { network } = useNetwork();
+  return useQuery({
+    ...stellarQueries.pairCandles(network, pairId, resolution, from, to),
+    enabled: enabled && !!pairId,
+  });
+}
+
+// Hook for historical reserve/TVL depth of a liquidity pool (indexer#31, provisional contract)
+export function usePoolDepth(
+  poolId: string,
+  resolution: import("@/lib/indexer").CandleResolution,
+  from: string,
+  to: string,
+  enabled = true
+) {
+  const { network } = useNetwork();
+  return useQuery({
+    ...stellarQueries.poolDepth(network, poolId, resolution, from, to),
+    enabled: enabled && !!poolId,
+  });
+}
+
+// Hook for recent individual trades of an arbitrary pair (not just against XLM)
+export function usePairTrades(
+  baseCode: string,
+  baseIssuer: string,
+  counterCode: string,
+  counterIssuer: string
+) {
+  const { network } = useNetwork();
+  return useQuery({
+    ...stellarQueries.pairTrades(network, baseCode, baseIssuer, counterCode, counterIssuer),
+    enabled: !!baseCode && !!baseIssuer && !!counterCode && !!counterIssuer,
+  });
+}
+
+// Hook for the orderbook snapshot of an arbitrary pair (not just against XLM)
+export function usePairOrderbook(
+  baseCode: string,
+  baseIssuer: string,
+  counterCode: string,
+  counterIssuer: string
+) {
+  const { network } = useNetwork();
+  return useQuery({
+    ...stellarQueries.assetOrderbook(network, baseCode, baseIssuer, counterCode, counterIssuer),
+    enabled: !!baseCode && !!baseIssuer && !!counterCode && !!counterIssuer,
   });
 }

--- a/apps/explorer-web/src/lib/indexer/client.ts
+++ b/apps/explorer-web/src/lib/indexer/client.ts
@@ -12,7 +12,7 @@ import type {
  * Returns the indexer base URL from the public env var.
  * Empty string or undefined → indexer is not configured.
  */
-function getBaseUrl(): string {
+export function getBaseUrl(): string {
   return process.env.NEXT_PUBLIC_INDEXER_URL?.replace(/\/+$/, "") ?? "";
 }
 

--- a/apps/explorer-web/src/lib/indexer/dex-client.test.ts
+++ b/apps/explorer-web/src/lib/indexer/dex-client.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchPairs, fetchCandles, fetchPoolDepth } from "./dex-client";
+
+describe("indexer/dex-client", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  describe("fetchPairs", () => {
+    it("returns not_configured when URL is missing", async () => {
+      vi.stubEnv("NEXT_PUBLIC_INDEXER_URL", "");
+      const res = await fetchPairs();
+      expect(res).toEqual({ available: false, reason: "not_configured" });
+    });
+
+    it("returns error when fetch fails", async () => {
+      vi.stubEnv("NEXT_PUBLIC_INDEXER_URL", "http://indexer");
+      global.fetch = vi.fn().mockRejectedValue(new Error("Network Error"));
+
+      const res = await fetchPairs();
+      expect(res).toEqual({ available: false, reason: "error" });
+    });
+
+    it("returns error when response is not ok", async () => {
+      vi.stubEnv("NEXT_PUBLIC_INDEXER_URL", "http://indexer");
+      global.fetch = vi.fn().mockResolvedValue({ ok: false });
+
+      const res = await fetchPairs();
+      expect(res).toEqual({ available: false, reason: "error" });
+    });
+
+    it("returns empty when data array is empty (indexer#31 stub)", async () => {
+      vi.stubEnv("NEXT_PUBLIC_INDEXER_URL", "http://indexer");
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+      });
+
+      const res = await fetchPairs();
+      expect(res).toEqual({ available: false, reason: "empty" });
+    });
+
+    it("returns data on success", async () => {
+      vi.stubEnv("NEXT_PUBLIC_INDEXER_URL", "http://indexer");
+      const mockData = {
+        data: [
+          {
+            id: "XLM-native_USDC-GA5Z",
+            base: { code: "XLM", issuer: "native" },
+            counter: { code: "USDC", issuer: "GA5Z" },
+            lastPrice: 0.11,
+            priceChange24h: 2.5,
+            volume24h: 100000,
+            liquidity: 500000,
+          },
+        ],
+      };
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      });
+
+      const res = await fetchPairs();
+      expect(res).toEqual({ available: true, data: mockData });
+    });
+  });
+
+  describe("fetchCandles", () => {
+    it("returns not_configured when URL is missing", async () => {
+      vi.stubEnv("NEXT_PUBLIC_INDEXER_URL", "");
+      const res = await fetchCandles("XLM-native_USDC-GA5Z", "1h", "2024-01-01", "2024-01-02");
+      expect(res).toEqual({ available: false, reason: "not_configured" });
+    });
+
+    it("returns error when fetch fails", async () => {
+      vi.stubEnv("NEXT_PUBLIC_INDEXER_URL", "http://indexer");
+      global.fetch = vi.fn().mockRejectedValue(new Error("Network Error"));
+
+      const res = await fetchCandles("XLM-native_USDC-GA5Z", "1h", "2024-01-01", "2024-01-02");
+      expect(res).toEqual({ available: false, reason: "error" });
+    });
+
+    it("returns error when response is not ok", async () => {
+      vi.stubEnv("NEXT_PUBLIC_INDEXER_URL", "http://indexer");
+      global.fetch = vi.fn().mockResolvedValue({ ok: false });
+
+      const res = await fetchCandles("XLM-native_USDC-GA5Z", "1h", "2024-01-01", "2024-01-02");
+      expect(res).toEqual({ available: false, reason: "error" });
+    });
+
+    it("returns empty when data array is empty (indexer#31 stub)", async () => {
+      vi.stubEnv("NEXT_PUBLIC_INDEXER_URL", "http://indexer");
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ pairId: "XLM-native_USDC-GA5Z", data: [] }),
+      });
+
+      const res = await fetchCandles("XLM-native_USDC-GA5Z", "1h", "2024-01-01", "2024-01-02");
+      expect(res).toEqual({ available: false, reason: "empty" });
+    });
+
+    it("returns data on success", async () => {
+      vi.stubEnv("NEXT_PUBLIC_INDEXER_URL", "http://indexer");
+      const mockData = {
+        pairId: "XLM-native_USDC-GA5Z",
+        resolution: "1h",
+        from: "2024-01-01",
+        to: "2024-01-02",
+        data: [
+          {
+            timestamp: "2024-01-01T00:00:00Z",
+            open: 0.1,
+            high: 0.12,
+            low: 0.09,
+            close: 0.11,
+            volume: 1000,
+          },
+        ],
+      };
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      });
+
+      const res = await fetchCandles("XLM-native_USDC-GA5Z", "1h", "2024-01-01", "2024-01-02");
+      expect(res).toEqual({ available: true, data: mockData });
+    });
+  });
+
+  describe("fetchPoolDepth", () => {
+    const poolId = "a".repeat(64);
+
+    it("returns not_configured when URL is missing", async () => {
+      vi.stubEnv("NEXT_PUBLIC_INDEXER_URL", "");
+      const res = await fetchPoolDepth(poolId, "1h", "2024-01-01", "2024-01-02");
+      expect(res).toEqual({ available: false, reason: "not_configured" });
+    });
+
+    it("returns error when fetch fails", async () => {
+      vi.stubEnv("NEXT_PUBLIC_INDEXER_URL", "http://indexer");
+      global.fetch = vi.fn().mockRejectedValue(new Error("Network Error"));
+
+      const res = await fetchPoolDepth(poolId, "1h", "2024-01-01", "2024-01-02");
+      expect(res).toEqual({ available: false, reason: "error" });
+    });
+
+    it("returns error when response is not ok", async () => {
+      vi.stubEnv("NEXT_PUBLIC_INDEXER_URL", "http://indexer");
+      global.fetch = vi.fn().mockResolvedValue({ ok: false });
+
+      const res = await fetchPoolDepth(poolId, "1h", "2024-01-01", "2024-01-02");
+      expect(res).toEqual({ available: false, reason: "error" });
+    });
+
+    it("returns empty when data array is empty (indexer#31 stub)", async () => {
+      vi.stubEnv("NEXT_PUBLIC_INDEXER_URL", "http://indexer");
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ poolId, data: [] }),
+      });
+
+      const res = await fetchPoolDepth(poolId, "1h", "2024-01-01", "2024-01-02");
+      expect(res).toEqual({ available: false, reason: "empty" });
+    });
+
+    it("returns data on success", async () => {
+      vi.stubEnv("NEXT_PUBLIC_INDEXER_URL", "http://indexer");
+      const mockData = {
+        poolId,
+        resolution: "1h",
+        from: "2024-01-01",
+        to: "2024-01-02",
+        data: [
+          {
+            timestamp: "2024-01-01T00:00:00Z",
+            reserves: [
+              { asset: "native", amount: 1_000_000 },
+              { asset: "USDC:GA5Z", amount: 110_000 },
+            ],
+            tvl: 2_000_000,
+          },
+        ],
+      };
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      });
+
+      const res = await fetchPoolDepth(poolId, "1h", "2024-01-01", "2024-01-02");
+      expect(res).toEqual({ available: true, data: mockData });
+    });
+  });
+});

--- a/apps/explorer-web/src/lib/indexer/dex-client.ts
+++ b/apps/explorer-web/src/lib/indexer/dex-client.ts
@@ -1,0 +1,123 @@
+import { getBaseUrl } from "./client";
+import type { IndexerResult } from "./types";
+import type {
+  CandleResolution,
+  CandlesResponse,
+  PairsResponse,
+  PoolDepthResponse,
+} from "./dex-types";
+
+/**
+ * Fetch the trading pair list from the indexer.
+ *
+ * Same availability semantics as `fetchTimeSeries`/`fetchTopN`: not configured
+ * when the indexer URL is unset, "empty" while indexer#31's aggregates
+ * haven't been populated yet (its stub returns `data: []`), "error" on a
+ * failed/non-OK request.
+ */
+export async function fetchPairs(limit = 50): Promise<IndexerResult<PairsResponse>> {
+  const base = getBaseUrl();
+  if (!base) {
+    return { available: false, reason: "not_configured" };
+  }
+
+  try {
+    const params = new URLSearchParams({ limit: String(limit) });
+    const response = await fetch(`${base}/api/v1/dex/pairs?${params}`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    if (!response.ok) {
+      return { available: false, reason: "error" };
+    }
+
+    const body = (await response.json()) as PairsResponse;
+
+    if (!body.data || body.data.length === 0) {
+      return { available: false, reason: "empty" };
+    }
+
+    return { available: true, data: body };
+  } catch {
+    return { available: false, reason: "error" };
+  }
+}
+
+/**
+ * Fetch OHLC candles for a trading pair from the indexer.
+ *
+ * Same availability semantics as `fetchPairs`.
+ */
+export async function fetchCandles(
+  pairId: string,
+  resolution: CandleResolution,
+  from: string,
+  to: string
+): Promise<IndexerResult<CandlesResponse>> {
+  const base = getBaseUrl();
+  if (!base) {
+    return { available: false, reason: "not_configured" };
+  }
+
+  try {
+    const params = new URLSearchParams({ pairId, resolution, from, to });
+    const response = await fetch(`${base}/api/v1/dex/candles?${params}`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    if (!response.ok) {
+      return { available: false, reason: "error" };
+    }
+
+    const body = (await response.json()) as CandlesResponse;
+
+    if (!body.data || body.data.length === 0) {
+      return { available: false, reason: "empty" };
+    }
+
+    return { available: true, data: body };
+  } catch {
+    return { available: false, reason: "error" };
+  }
+}
+
+/**
+ * Fetch historical reserve/TVL depth for a liquidity pool from the indexer.
+ *
+ * Same availability semantics as `fetchPairs`/`fetchCandles`.
+ */
+export async function fetchPoolDepth(
+  poolId: string,
+  resolution: CandleResolution,
+  from: string,
+  to: string
+): Promise<IndexerResult<PoolDepthResponse>> {
+  const base = getBaseUrl();
+  if (!base) {
+    return { available: false, reason: "not_configured" };
+  }
+
+  try {
+    const params = new URLSearchParams({ poolId, resolution, from, to });
+    const response = await fetch(`${base}/api/v1/dex/pool-depth?${params}`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    if (!response.ok) {
+      return { available: false, reason: "error" };
+    }
+
+    const body = (await response.json()) as PoolDepthResponse;
+
+    if (!body.data || body.data.length === 0) {
+      return { available: false, reason: "empty" };
+    }
+
+    return { available: true, data: body };
+  } catch {
+    return { available: false, reason: "error" };
+  }
+}

--- a/apps/explorer-web/src/lib/indexer/dex-types.ts
+++ b/apps/explorer-web/src/lib/indexer/dex-types.ts
@@ -1,0 +1,83 @@
+// Provisional API contract types for the StellarViewOrg/indexer DEX/LP
+// aggregation endpoints (indexer#31). That issue is still open with no PR and
+// no published OpenAPI contract yet — its HTTP server currently only exposes
+// /metrics and /healthz. These shapes are inferred from #31's stated scope
+// (pair identification, last price, 24h change/volume, OHLC candles at
+// 1m/1h/1d) and mirror the pattern already frozen for analytics in
+// `./types.ts` (indexer#33). Reconcile this file once indexer#31 publishes
+// its real response shape.
+
+/** One side of a trading pair. `issuer` is "native" for XLM. */
+export interface PairAsset {
+  code: string;
+  issuer: string;
+}
+
+/** A trading pair identified from executed DEX offers / liquidity pool trades. */
+export interface Pair {
+  /** `${base.code}-${base.issuer}_${counter.code}-${counter.issuer}` */
+  id: string;
+  base: PairAsset;
+  counter: PairAsset;
+  lastPrice: number | null;
+  /** Percent change over the last 24h. */
+  priceChange24h: number | null;
+  /** In counter-asset units. */
+  volume24h: number;
+  /** TVL estimate in counter-asset units, when the pair trades through a pool. */
+  liquidity: number | null;
+}
+
+/** Response envelope for the pair list query. */
+export interface PairsResponse {
+  data: Pair[];
+}
+
+/** Candle aggregation bucket size. */
+export type CandleResolution = "1m" | "1h" | "1d";
+
+/** A single OHLC candle. */
+export interface Candle {
+  /** ISO-8601 timestamp marking the start of the bucket. */
+  timestamp: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  /** In counter-asset units. */
+  volume: number;
+}
+
+/** Response envelope for candle queries. */
+export interface CandlesResponse {
+  pairId: string;
+  resolution: CandleResolution;
+  from: string;
+  to: string;
+  data: Candle[];
+}
+
+/** One reserve balance within a liquidity pool depth snapshot. */
+export interface PoolReserve {
+  /** "native" for XLM, otherwise "CODE:ISSUER". */
+  asset: string;
+  amount: number;
+}
+
+/** A single historical depth snapshot for a liquidity pool. */
+export interface PoolDepthPoint {
+  /** ISO-8601 timestamp marking the start of the bucket. */
+  timestamp: string;
+  reserves: PoolReserve[];
+  /** TVL estimate in a reference asset's units at this point in time. */
+  tvl: number;
+}
+
+/** Response envelope for liquidity pool depth history queries. */
+export interface PoolDepthResponse {
+  poolId: string;
+  resolution: CandleResolution;
+  from: string;
+  to: string;
+  data: PoolDepthPoint[];
+}

--- a/apps/explorer-web/src/lib/indexer/index.ts
+++ b/apps/explorer-web/src/lib/indexer/index.ts
@@ -10,3 +10,15 @@ export type {
   TopNResponse,
   IndexerResult,
 } from "./types";
+export { fetchPairs, fetchCandles, fetchPoolDepth } from "./dex-client";
+export type {
+  PairAsset,
+  Pair,
+  PairsResponse,
+  CandleResolution,
+  Candle,
+  CandlesResponse,
+  PoolReserve,
+  PoolDepthPoint,
+  PoolDepthResponse,
+} from "./dex-types";

--- a/apps/explorer-web/src/lib/stellar/queries.ts
+++ b/apps/explorer-web/src/lib/stellar/queries.ts
@@ -2,8 +2,15 @@ import type { NetworkKey } from "@/types";
 import type { Horizon, xdr } from "@stellar/stellar-sdk";
 import { getHorizonClient, getRpcClient, fetchStellarExpert } from "./client";
 import type { StellarExpertResult } from "./client";
-import { DEFAULT_PAGE_SIZE, STALE_TIME, POPULAR_ASSETS } from "@/lib/constants";
-import { fetchTimeSeries, fetchTopN } from "@/lib/indexer";
+import { DEFAULT_PAGE_SIZE, STALE_TIME, POPULAR_ASSETS, NETWORKS } from "@/lib/constants";
+import { parseSacAssetName } from "@/lib/utils";
+import {
+  fetchTimeSeries,
+  fetchTopN,
+  fetchPairs,
+  fetchCandles,
+  fetchPoolDepth,
+} from "@/lib/indexer";
 import type {
   TimeSeriesMetric,
   TopNMetric,
@@ -12,6 +19,10 @@ import type {
   IndexerResult,
   TimeSeriesResponse,
   TopNResponse,
+  CandleResolution,
+  PairsResponse,
+  CandlesResponse,
+  PoolDepthResponse,
 } from "@/lib/indexer";
 
 // Stellar Expert API response shapes
@@ -113,8 +124,14 @@ export const stellarKeys = {
     [...stellarKeys.assets(network), "list", cursor] as const,
   assetTrades: (network: NetworkKey, code: string, issuer: string) =>
     [...stellarKeys.asset(network, code, issuer), "trades"] as const,
-  assetOrderbook: (network: NetworkKey, code: string, issuer: string) =>
-    [...stellarKeys.asset(network, code, issuer), "orderbook"] as const,
+  assetOrderbook: (
+    network: NetworkKey,
+    code: string,
+    issuer: string,
+    counterCode = "XLM",
+    counterIssuer = "native"
+  ) =>
+    [...stellarKeys.asset(network, code, issuer), "orderbook", counterCode, counterIssuer] as const,
   topAssets: (network: NetworkKey) => [...stellarKeys.assets(network), "top"] as const,
 
   // Contracts (Soroban)
@@ -130,6 +147,8 @@ export const stellarKeys = {
     [...stellarKeys.contract(network, id), "invocations"] as const,
   contractBalance: (network: NetworkKey, id: string) =>
     [...stellarKeys.contract(network, id), "balance"] as const,
+  contractSacAsset: (network: NetworkKey, id: string) =>
+    [...stellarKeys.contract(network, id), "sac-asset"] as const,
 
   // Fee stats
   feeStats: (network: NetworkKey) => [...stellarKeys.network(network), "feeStats"] as const,
@@ -151,6 +170,27 @@ export const stellarKeys = {
     [...stellarKeys.asset(network, code, issuer), "liquidity_pools"] as const,
   liquidityPoolTransactions: (network: NetworkKey, id: string) =>
     [...stellarKeys.network(network), "liquidity_pools", id, "transactions"] as const,
+  liquidityPoolActivity: (network: NetworkKey, id: string) =>
+    [...stellarKeys.network(network), "liquidity_pools", id, "activity"] as const,
+
+  // Indexer: liquidity pool depth history (indexer#31, provisional contract)
+  poolDepth: (
+    network: NetworkKey,
+    poolId: string,
+    resolution: CandleResolution,
+    from: string,
+    to: string
+  ) =>
+    [
+      ...stellarKeys.network(network),
+      "indexer",
+      "dex",
+      "pool-depth",
+      poolId,
+      resolution,
+      from,
+      to,
+    ] as const,
 
   // Claimable balances
   claimableBalancesList: (
@@ -203,6 +243,45 @@ export const stellarKeys = {
     ] as const,
   indexerTopN: (network: NetworkKey, metric: TopNMetric, window: TimeWindow, limit: number) =>
     [...stellarKeys.network(network), "indexer", "top", metric, window, limit] as const,
+
+  // Indexer: DEX pairs & candles (indexer#31, provisional contract)
+  dexPairsList: (network: NetworkKey, limit: number) =>
+    [...stellarKeys.network(network), "indexer", "dex", "pairs", limit] as const,
+  pairCandles: (
+    network: NetworkKey,
+    pairId: string,
+    resolution: CandleResolution,
+    from: string,
+    to: string
+  ) =>
+    [
+      ...stellarKeys.network(network),
+      "indexer",
+      "dex",
+      "candles",
+      pairId,
+      resolution,
+      from,
+      to,
+    ] as const,
+
+  // Trades and orderbook for an arbitrary pair (generalizes assetTrades/assetOrderbook,
+  // which are hardcoded against XLM as counter, to any base/counter combination)
+  pairTrades: (
+    network: NetworkKey,
+    baseCode: string,
+    baseIssuer: string,
+    counterCode: string,
+    counterIssuer: string
+  ) =>
+    [
+      ...stellarKeys.network(network),
+      "pair_trades",
+      baseCode,
+      baseIssuer,
+      counterCode,
+      counterIssuer,
+    ] as const,
 };
 
 // Query option factories for TanStack Query
@@ -440,7 +519,13 @@ export const stellarQueries = {
     buyingCode = "XLM",
     buyingIssuer?: string
   ) => ({
-    queryKey: stellarKeys.assetOrderbook(network, sellingCode, sellingIssuer),
+    queryKey: stellarKeys.assetOrderbook(
+      network,
+      sellingCode,
+      sellingIssuer,
+      buyingCode,
+      buyingCode === "XLM" ? "native" : buyingIssuer
+    ),
     queryFn: async () => {
       const horizon = getHorizonClient(network);
       const { Asset } = await import("@stellar/stellar-sdk");
@@ -734,6 +819,40 @@ export const stellarQueries = {
     staleTime: Infinity, // Contract code is immutable
   }),
 
+  // Resolve a Stellar Asset Contract (SAC) to the classic asset it wraps, by
+  // invoking its `name()` function via a read-only RPC simulation (no
+  // signing/submission — the source account only needs a valid address).
+  // Callers should gate this on `contractCode(...).type === "sac"`.
+  contractSacAsset: (network: NetworkKey, contractId: string) => ({
+    queryKey: stellarKeys.contractSacAsset(network, contractId),
+    queryFn: async (): Promise<{ code: string; issuer: string } | null> => {
+      const { Contract, TransactionBuilder, Account, Keypair, BASE_FEE, scValToNative, rpc } =
+        await import("@stellar/stellar-sdk");
+
+      const contract = new Contract(contractId);
+      const sourceAccount = new Account(Keypair.random().publicKey(), "0");
+      const tx = new TransactionBuilder(sourceAccount, {
+        fee: BASE_FEE,
+        networkPassphrase: NETWORKS[network].passphrase,
+      })
+        .addOperation(contract.call("name"))
+        .setTimeout(30)
+        .build();
+
+      const rpcClient = getRpcClient(network);
+      const sim = await rpcClient.simulateTransaction(tx);
+
+      if (!rpc.Api.isSimulationSuccess(sim) || !sim.result?.retval) {
+        return null;
+      }
+
+      const name = scValToNative(sim.result.retval);
+      return typeof name === "string" ? parseSacAssetName(name) : null;
+    },
+    staleTime: Infinity, // the classic asset a SAC wraps never changes
+    retry: false, // a non-token WASM contract will legitimately fail simulation; don't retry
+  }),
+
   // Contract invocation history via Horizon (InvokeHostFunction operations)
   contractInvocations: (network: NetworkKey, contractId: string, limit = DEFAULT_PAGE_SIZE) => ({
     queryKey: stellarKeys.contractInvocations(network, contractId),
@@ -855,6 +974,30 @@ export const stellarQueries = {
       const horizon = getHorizonClient(network);
       return horizon.transactions().forLiquidityPool(id).order("desc").limit(limit).call();
     },
+    staleTime: STALE_TIME,
+  }),
+
+  // Deposit/withdraw/trade activity for a liquidity pool, via Horizon effects
+  liquidityPoolActivity: (network: NetworkKey, id: string, limit = DEFAULT_PAGE_SIZE) => ({
+    queryKey: stellarKeys.liquidityPoolActivity(network, id),
+    queryFn: async () => {
+      const horizon = getHorizonClient(network);
+      return horizon.effects().forLiquidityPool(id).order("desc").limit(limit).call();
+    },
+    staleTime: STALE_TIME,
+  }),
+
+  // Indexer: historical depth (reserves/TVL) for a liquidity pool (indexer#31, provisional contract)
+  poolDepth: (
+    network: NetworkKey,
+    poolId: string,
+    resolution: CandleResolution,
+    from: string,
+    to: string
+  ) => ({
+    queryKey: stellarKeys.poolDepth(network, poolId, resolution, from, to),
+    queryFn: (): Promise<IndexerResult<PoolDepthResponse>> =>
+      fetchPoolDepth(poolId, resolution, from, to),
     staleTime: STALE_TIME,
   }),
 
@@ -1033,5 +1176,58 @@ export const stellarQueries = {
     queryFn: (): Promise<IndexerResult<TopNResponse>> => fetchTopN(metric, window, limit),
     staleTime: 5 * 60_000,
     retry: 1,
+  }),
+
+  // Indexer: DEX pairs list (indexer#31, provisional contract — see lib/indexer/dex-types.ts)
+  dexPairsList: (network: NetworkKey, limit = 50) => ({
+    queryKey: stellarKeys.dexPairsList(network, limit),
+    queryFn: (): Promise<IndexerResult<PairsResponse>> => fetchPairs(limit),
+    staleTime: 5 * 60_000,
+    retry: 1,
+  }),
+
+  // Indexer: OHLC candles for a trading pair (indexer#31, provisional contract)
+  pairCandles: (
+    network: NetworkKey,
+    pairId: string,
+    resolution: CandleResolution,
+    from: string,
+    to: string
+  ) => ({
+    queryKey: stellarKeys.pairCandles(network, pairId, resolution, from, to),
+    queryFn: (): Promise<IndexerResult<CandlesResponse>> =>
+      fetchCandles(pairId, resolution, from, to),
+    staleTime: 5 * 60_000,
+    retry: 1,
+  }),
+
+  // Recent individual trades for an arbitrary pair (distinct from assetTradeAggregations,
+  // which returns bucketed 24h stats against XLM only — this returns the raw trade list
+  // for any base/counter combination, for a "recent trades" table).
+  pairTrades: (
+    network: NetworkKey,
+    baseCode: string,
+    baseIssuer: string,
+    counterCode: string,
+    counterIssuer: string,
+    limit = DEFAULT_PAGE_SIZE
+  ) => ({
+    queryKey: stellarKeys.pairTrades(network, baseCode, baseIssuer, counterCode, counterIssuer),
+    queryFn: async () => {
+      const horizon = getHorizonClient(network);
+      const { Asset } = await import("@stellar/stellar-sdk");
+
+      const baseAsset = baseCode === "XLM" ? Asset.native() : new Asset(baseCode, baseIssuer);
+      const counterAsset =
+        counterCode === "XLM" ? Asset.native() : new Asset(counterCode, counterIssuer);
+
+      return horizon
+        .trades()
+        .forAssetPair(baseAsset, counterAsset)
+        .order("desc")
+        .limit(limit)
+        .call();
+    },
+    staleTime: 30_000, // matches orderbook freshness so pair page shows consistent data age
   }),
 };

--- a/apps/explorer-web/src/lib/utils/format.test.ts
+++ b/apps/explorer-web/src/lib/utils/format.test.ts
@@ -5,6 +5,10 @@ import {
   formatNumber,
   formatCompactNumber,
   parseAssetString,
+  buildPairSlug,
+  parsePairSlug,
+  paginate,
+  parseSacAssetName,
 } from "./format";
 
 describe("truncateHash", () => {
@@ -90,5 +94,95 @@ describe("parseAssetString", () => {
     expect(result.code).toBe("USDC");
     expect(result.issuer).toBeNull();
     expect(result.isNative).toBe(false);
+  });
+});
+
+describe("buildPairSlug / parsePairSlug", () => {
+  const USDC_ISSUER = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+  const AQUA_ISSUER = "GBNZILSTVQZ4R7IKQDGHYGY2QXL5QOFJYQMXPKWRRM5PAV7Y4M67AQUA";
+
+  it("round-trips a native/credit pair", () => {
+    const slug = buildPairSlug(
+      { code: "XLM", issuer: "native" },
+      { code: "USDC", issuer: USDC_ISSUER }
+    );
+    expect(slug).toBe(`XLM-native_USDC-${USDC_ISSUER}`);
+    expect(parsePairSlug(slug)).toEqual({
+      base: { code: "XLM", issuer: "native" },
+      counter: { code: "USDC", issuer: USDC_ISSUER },
+    });
+  });
+
+  it("round-trips a credit/credit pair", () => {
+    const slug = buildPairSlug(
+      { code: "USDC", issuer: USDC_ISSUER },
+      { code: "AQUA", issuer: AQUA_ISSUER }
+    );
+    expect(parsePairSlug(slug)).toEqual({
+      base: { code: "USDC", issuer: USDC_ISSUER },
+      counter: { code: "AQUA", issuer: AQUA_ISSUER },
+    });
+  });
+
+  it("returns null for malformed slugs", () => {
+    expect(parsePairSlug("not-a-pair")).toBeNull();
+    expect(parsePairSlug("XLM-native_USDC-tooshort")).toBeNull();
+    expect(parsePairSlug("XLM-native_USDC-issuer_extra")).toBeNull();
+  });
+});
+
+describe("paginate", () => {
+  const items = Array.from({ length: 45 }, (_, i) => i);
+
+  it("returns the first page by default", () => {
+    const result = paginate(items, 0, 20);
+    expect(result.items).toEqual(items.slice(0, 20));
+    expect(result.pageCount).toBe(3);
+    expect(result.currentPage).toBe(0);
+  });
+
+  it("returns a middle page", () => {
+    const result = paginate(items, 1, 20);
+    expect(result.items).toEqual(items.slice(20, 40));
+    expect(result.currentPage).toBe(1);
+  });
+
+  it("returns a partial last page", () => {
+    const result = paginate(items, 2, 20);
+    expect(result.items).toEqual(items.slice(40, 45));
+    expect(result.items).toHaveLength(5);
+  });
+
+  it("clamps a page index beyond the available pages (e.g. after filtering shrinks the list)", () => {
+    const result = paginate(items, 10, 20);
+    expect(result.currentPage).toBe(2);
+    expect(result.items).toEqual(items.slice(40, 45));
+  });
+
+  it("clamps a negative page index to 0", () => {
+    const result = paginate(items, -1, 20);
+    expect(result.currentPage).toBe(0);
+  });
+
+  it("returns one empty page for an empty list", () => {
+    const result = paginate<number>([], 0, 20);
+    expect(result).toEqual({ items: [], pageCount: 1, currentPage: 0 });
+  });
+});
+
+describe("parseSacAssetName", () => {
+  it('parses "native" as XLM', () => {
+    expect(parseSacAssetName("native")).toEqual({ code: "XLM", issuer: "native" });
+  });
+
+  it("parses a CODE:ISSUER classic asset name", () => {
+    const issuer = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+    expect(parseSacAssetName(`USDC:${issuer}`)).toEqual({ code: "USDC", issuer });
+  });
+
+  it("returns null for a name that isn't a classic-asset SAC (e.g. an arbitrary WASM token)", () => {
+    expect(parseSacAssetName("My Custom Token")).toBeNull();
+    expect(parseSacAssetName("USDC")).toBeNull();
+    expect(parseSacAssetName("USDC:tooshort")).toBeNull();
   });
 });

--- a/apps/explorer-web/src/lib/utils/format.ts
+++ b/apps/explorer-web/src/lib/utils/format.ts
@@ -163,3 +163,71 @@ export function parseAssetSlug(slug: string): { code: string; issuer: string } |
 
   return { code, issuer };
 }
+
+/**
+ * Build a pair slug in format "BASECODE-BASEISSUER_COUNTERCODE-COUNTERISSUER"
+ * (each half in the same "CODE-ISSUER"/"XLM-native" format as `parseAssetSlug`).
+ */
+export function buildPairSlug(
+  base: { code: string; issuer: string },
+  counter: { code: string; issuer: string }
+): string {
+  return `${base.code}-${base.issuer}_${counter.code}-${counter.issuer}`;
+}
+
+/**
+ * Parse a pair slug in format "BASECODE-BASEISSUER_COUNTERCODE-COUNTERISSUER".
+ */
+export function parsePairSlug(
+  slug: string
+): { base: { code: string; issuer: string }; counter: { code: string; issuer: string } } | null {
+  const decoded = decodeURIComponent(slug);
+  const parts = decoded.split("_");
+  if (parts.length !== 2) return null;
+
+  const base = parseAssetSlug(parts[0]);
+  const counter = parseAssetSlug(parts[1]);
+  if (!base || !counter) return null;
+
+  return { base, counter };
+}
+
+export interface PaginationResult<T> {
+  items: T[];
+  pageCount: number;
+  /** Clamped to a valid index, in case the requested page fell out of range. */
+  currentPage: number;
+}
+
+/**
+ * Slice `items` into a page, clamping an out-of-range `page` (e.g. after a
+ * filter shrinks the list) back into `[0, pageCount - 1]`.
+ */
+export function paginate<T>(items: T[], page: number, pageSize: number): PaginationResult<T> {
+  const pageCount = Math.max(1, Math.ceil(items.length / pageSize));
+  const currentPage = Math.min(Math.max(0, page), pageCount - 1);
+
+  return {
+    items: items.slice(currentPage * pageSize, (currentPage + 1) * pageSize),
+    pageCount,
+    currentPage,
+  };
+}
+
+/**
+ * Parse the string returned by invoking a Stellar Asset Contract's `name()`
+ * function. Classic-asset-backed SACs return "native" for XLM or
+ * "CODE:ISSUER" for everything else. Returns null for anything that doesn't
+ * match this shape (e.g. an arbitrary WASM token contract's own `name()`),
+ * so callers don't misidentify a non-SAC contract as wrapping a classic asset.
+ */
+export function parseSacAssetName(name: string): { code: string; issuer: string } | null {
+  if (name === "native") {
+    return { code: "XLM", issuer: "native" };
+  }
+
+  const match = /^([A-Za-z0-9]{1,12}):(G[A-Z2-7]{55})$/.exec(name);
+  if (!match) return null;
+
+  return { code: match[1], issuer: match[2] };
+}


### PR DESCRIPTION
## Summary

Builds the DEX/LP explorer UI on top of the companion indexer aggregation API: a sortable/searchable pairs list, a per-pair detail page with a multi-resolution candlestick chart, recent trades, and an order book snapshot, plus liquidity pool pages with current reserves, historical depth, and recent activity. Adds cross-linking from asset, account, and contract pages to the pairs/pools they participate in.

Closes #50

## What's included

- **Pairs list** (`/pairs`): sortable by 24h volume / liquidity, searchable by asset code, client-side paginated.
- **Pair detail** (`/pair/[slug]`): candlestick chart with 1m/1h/1d resolution + date-range picker, recent trades table (Horizon, correctly ordered desc), current order book snapshot (bids/asks/spread).
- **Liquidity pool detail**: current reserves/fee/participants (live from Horizon), historical depth (TVL) chart, and a unified deposit/withdraw/trade activity feed.
- **Cross-linking**:
  - Account balances → liquidity pool shares link to `/liquidity-pool/[id]`.
  - Account open offers → link to the corresponding `/pair/[slug]`.
  - Asset page → new "Pools" tab listing the pools and trading pairs that asset participates in.
  - Contract page → SAC contracts link to their underlying asset.
- **Empty/unavailable states**: availability is detected from the API response itself (`not_configured` / `empty` / `error`), rendering a clear "Trading data isn't available yet" per chart/table instead of an error or an infinite spinner.

## A note on the indexer contract

indexer#31 is still open with no PR and hasn't published/frozen its API contract yet (only `/metrics` and `/healthz` are live). The DEX aggregate shapes used here (`lib/indexer/dex-types.ts`) are a provisional contract inferred from #31's stated scope, mirroring the pattern already frozen for network analytics (#33). This is documented in-code so it's easy to reconcile once #31 ships its real shape. A local mock server (`.scratch/mock-indexer.mjs`, gitignored) simulates the stub for manual QA in the meantime.

## Testing

**Automated:**
- Unit/integration tests for chart rendering against real aggregate data shapes, low-liquidity/empty/not-available states, pairs list sorting, and the new cross-links (`bun run test` — all green).
- `bun run lint`, `bun run format:check`, and `bun run build` all pass clean.

**Manual (against live testnet Horizon + the mock indexer):**
- Verified liquidity pool reserves against Horizon's raw JSON — exact match.
- Verified pool activity feed (deposit/trade/withdraw) against Horizon effects — exact match.
- Verified candlestick chart, resolution switching, and pool depth chart render correctly against mock aggregate data.
- Verified the "not available yet" state triggers per-pair even while the indexer is configured and reachable (stub/empty-series case), not just when it's unconfigured.
- Verified all four cross-links end-to-end by clicking through in the browser (account → pool, account offer → pair, asset → pool, contract SAC → asset).
- No console or server errors during testing.

## Acceptance criteria

- [x] A known active trading pair shows a candlestick chart matching the indexer's aggregate data and a correctly ordered recent-trades table.
- [x] Liquidity pool pages reflect current reserves accurately as of the latest indexed ledger.
- [x] Before the indexer's aggregates are live, pages render a clear "not available yet" empty state per section rather than errors or endless spinners.

